### PR TITLE
Razor conversion improvement

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,10 +88,13 @@ func main() {
 			os.Args = append([]string{os.Args[0]}, append([]string{"run"}, os.Args[1:]...)...)
 		}
 	}
+
+	var changedArgs []int
 	for i := range os.Args {
 		// There is a problem with kingpin, it tries to interpret arguments beginning with @ as file
 		if strings.HasPrefix(os.Args[i], "@") {
-			os.Args[i] = "#" + os.Args[i]
+			os.Args[i] = "#!!" + os.Args[i]
+			changedArgs = append(changedArgs, i)
 		}
 		if os.Args[i] == "--base" {
 			for n := range options {
@@ -104,6 +107,13 @@ func main() {
 	kingpin.CommandLine = app
 	kingpin.CommandLine.HelpFlag.Short('h')
 	command := kingpin.Parse()
+
+	// We restore back the modified arguments
+	for i := range *templates {
+		if strings.HasPrefix((*templates)[i], "#!!") {
+			(*templates)[i] = (*templates)[i][3:]
+		}
+	}
 
 	// Build the optionsSet
 	var optionsSet template.OptionsSet

--- a/template/extra_runtime.go
+++ b/template/extra_runtime.go
@@ -262,7 +262,9 @@ func (t Template) runTemplateItf(source string, context ...interface{}) (interfa
 // This function is used to call a function that requires its last argument to be expanded ...
 func (t Template) ellipsis(function string, args ...interface{}) (interface{}, error) {
 	last := len(args) - 1
-	if last < 0 || reflect.TypeOf(args[last]).Kind() != reflect.Slice {
+	if last >= 0 && args[last] == nil {
+		args[last] = []interface{}{}
+	} else if last < 0 || reflect.TypeOf(args[last]).Kind() != reflect.Slice {
 		return nil, fmt.Errorf("The last argument must be a slice")
 	}
 

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -41,7 +41,10 @@ func (s String) LastIndexFunc(f func(rune) bool) int { return strings.LastIndexF
 func (s String) Lines() StringArray                  { return s.Split("\n") }
 func (s String) Map(mapping func(rune) rune) String  { return String(strings.Map(mapping, string(s))) }
 func (s String) Repeat(count int) String             { return String(strings.Repeat(string(s), count)) }
-func (s String) Replace(old, new string, n int) String {
+func (s String) Replace(old, new string) String {
+	return String(strings.Replace(string(s), old, new, -1))
+}
+func (s String) ReplaceN(old, new string, n int) String {
 	return String(strings.Replace(string(s), old, new, n))
 }
 func (s String) Split(sep string) StringArray { return stringArray(strings.Split(string(s), sep)) }
@@ -283,7 +286,7 @@ func IndentN(s string, indent int) string { return Indent(s, strings.Repeat(" ",
 func PrettyPrintStruct(object interface{}) string {
 	var out string
 	isZero := func(x interface{}) bool {
-		return reflect.DeepEqual(x, reflect.Zero(reflect.TypeOf(x)).Interface())
+		return x == nil || reflect.DeepEqual(x, reflect.Zero(reflect.TypeOf(x)).Interface())
 	}
 
 	val := reflect.ValueOf(object)


### PR DESCRIPTION
- Fix a problem with ellipsis function when the last argument was nil
- Fix problem where @elseif was not working properly
- Add support for $var := expression instead of @$var := expression (the simplified version, $var := ..., requires the expression to be valid go expression while the @$var := ... supports both go or go template expression.
- Add flexibility on corner cases when there is a string contains special characters such as ; @ or {}