### PR TITLE
Change behaviour of `-@` and fix error management problem

### DIFF
--- a/doc_test/literals.md
+++ b/doc_test/literals.md
@@ -20,3 +20,40 @@ In that case, the result of `@john.doe@(company.com)` will be `123.453.141592653
 You can also render the &#64; characters by writing &#64;&#64;.
 
 So this `@@` will render &#64;.
+
+## Space management
+
+With go template, the way to indicate that previous or leading spaces between expression should be removed is expressed
+that way `{{- "expression" -}}`. The minus sign at the beginning and at the end mean that the spaces should be remove while
+`{{- "expression" }}` means to remove only at the beginning and `{{ "expression" -}}` means to remove only at the end.
+
+The `{{ "expression" }}` will keep the spaces before and after expression as they are.
+
+With razor, assignation and flow control expression (if, else, elseif, end, range, with, etc.) will render go template code with - at both end.
+
+@expr := "expression"
+
+results in:
+
+ {{- set $ "expr" ("expression") -}}
+
+But for variables, you have to specify the expected behavior.
+
+This signify that in the following sentence:
+
+    *The word @expr will stay in the normal flow,
+    but @-expr will be struck on the previous word*
+
+results in:
+
+    *The word expression will stay in the normal flow,
+    butexpression will be struck on the previous one*
+
+You can also specify that the expression should be preceded by a new line:
+
+    *The word @<expr will be on a new line*
+
+results in:
+
+    *The word
+expression will be on a new line*

--- a/doc_test/literals.razor
+++ b/doc_test/literals.razor
@@ -20,3 +20,40 @@ In that case, the result of `{{ $.john.doe }}{{ $.company.com }}` will be `123.4
 You can also render the &#64; characters by writing &#64;&#64;.
 
 So this `@` will render &#64;.
+
+## Space management
+
+With go template, the way to indicate that previous or leading spaces between expression should be removed is expressed
+that way `{{- "expression" -}}`. The minus sign at the beginning and at the end mean that the spaces should be remove while
+`{{- "expression" }}` means to remove only at the beginning and `{{ "expression" -}}` means to remove only at the end.
+
+The `{{ "expression" }}` will keep the spaces before and after expression as they are.
+
+With razor, assignation and flow control expression (if, else, elseif, end, range, with, etc.) will render go template code with - at both end.
+
+{{- set $ "expr" ("expression") }}
+
+results in:
+
+ {{- set $ "expr" ("expression") -}}
+
+But for variables, you have to specify the expected behavior.
+
+This signify that in the following sentence:
+
+    *The word {{ $.expr }} will stay in the normal flow,
+    but {{- $.expr }} will be struck on the previous word*
+
+results in:
+
+    *The word expression will stay in the normal flow,
+    butexpression will be struck on the previous one*
+
+You can also specify that the expression should be preceded by a new line:
+
+    *The word {{- $.NEWLINE }}{{ $.expr }} will be on a new line*
+
+results in:
+
+    *The word
+expression will be on a new line*

--- a/doc_test/literals.render
+++ b/doc_test/literals.render
@@ -18,3 +18,35 @@ In that case, the result of `123.453.141592653589793` will be `123.453.141592653
 You can also render the &#64; characters by writing &#64;&#64;.
 
 So this `@` will render &#64;.
+
+## Space management
+
+With go template, the way to indicate that previous or leading spaces between expression should be removed is expressed
+that way `expression`. The minus sign at the beginning and at the end mean that the spaces should be remove while
+`expression` means to remove only at the beginning and `expression` means to remove only at the end.
+
+The `expression` will keep the spaces before and after expression as they are.
+
+With razor, assignation and flow control expression (if, else, elseif, end, range, with, etc.) will render go template code with - at both end.
+
+results in:But for variables, you have to specify the expected behavior.
+
+This signify that in the following sentence:
+
+    *The word expression will stay in the normal flow,
+    butexpression will be struck on the previous word*
+
+results in:
+
+    *The word expression will stay in the normal flow,
+    butexpression will be struck on the previous one*
+
+You can also specify that the expression should be preceded by a new line:
+
+    *The word
+expression will be on a new line*
+
+results in:
+
+    *The word
+expression will be on a new line*

--- a/template/template.go
+++ b/template/template.go
@@ -241,13 +241,14 @@ func (t Template) ProcessTemplate(template, sourceFolder, targetFolder string) (
 }
 
 // ProcessTemplates loads and runs the file template or execute the content if it is not a file
-func (t Template) ProcessTemplates(sourceFolder, targetFolder string, templates ...string) (resultFiles []string, errors errors.Array) {
+func (t Template) ProcessTemplates(sourceFolder, targetFolder string, templates ...string) (resultFiles []string, err error) {
 	sourceFolder = iif(sourceFolder == "", t.folder, sourceFolder).(string)
 	targetFolder = iif(targetFolder == "", t.folder, targetFolder).(string)
 	resultFiles = make([]string, 0, len(templates))
 
 	print := t.options[OutputStdout]
 
+	var errors errors.Array
 	for i := range templates {
 		t.options[OutputStdout] = print // Some file may change this option at runtime, so we restore it back to its original value between each file
 		resultFile, err := t.ProcessTemplate(templates[i], sourceFolder, targetFolder)
@@ -258,6 +259,9 @@ func (t Template) ProcessTemplates(sourceFolder, targetFolder string, templates 
 		} else {
 			errors = append(errors, err)
 		}
+	}
+	if len(errors) > 0 {
+		err = errors
 	}
 	return
 }


### PR DESCRIPTION
- Fix problem with expression such as `-@var` that are interpreted as `{{- $.var }}`. They could lead to confusion. Moved the - after the @ to get the expected result `@-var` will result in `{{- $.var }}` while -@var will result in `-{{ $.var }}`
- Errors in ProcessTemplates was not handled correctly, we cannot return an errors.Array as error, it is interpreted as error event if the array is nil or empty.
- Add syntax `@{a}` to access local variables. This is equivalent to `@$a`, but less ugly.
- Add syntax `@<var` to indicate that we want a newline before the resulting value.