### PR TITLE
Set default context type to the first input file type

### DIFF
--- a/collections/convert_data_test.go
+++ b/collections/convert_data_test.go
@@ -8,6 +8,8 @@ import (
 type dictionary = map[string]interface{}
 
 func TestToNativeRepresentation(t *testing.T) {
+	t.Parallel()
+
 	type SubStruct struct {
 		U int64
 		I interface{}
@@ -69,6 +71,8 @@ func TestToNativeRepresentation(t *testing.T) {
 }
 
 func Test_quote(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		arg  string
@@ -76,7 +80,6 @@ func Test_quote(t *testing.T) {
 	}{
 		{"Simple value", "Foo", "Foo"},
 		{"Simple value", "Foo Bar", `"Foo Bar"`},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/collections/implementation/dict_helper_test.go
+++ b/collections/implementation/dict_helper_test.go
@@ -3,6 +3,8 @@ package implementation
 import "testing"
 
 func Test_baseDict_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    baseDict

--- a/collections/implementation/generic_test.go
+++ b/collections/implementation/generic_test.go
@@ -12,6 +12,8 @@ import (
 var strFixture = baseList(baseListHelper.NewStringList(strings.Split("Hello World, I'm Foo Bar!", " ")...).AsArray())
 
 func Test_list_Append(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      baseIList
@@ -33,6 +35,8 @@ func Test_list_Append(t *testing.T) {
 }
 
 func Test_list_Prepend(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      baseIList
@@ -54,6 +58,8 @@ func Test_list_Prepend(t *testing.T) {
 }
 
 func Test_list_AsArray(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -73,6 +79,8 @@ func Test_list_AsArray(t *testing.T) {
 }
 
 func Test_baseList_Strings(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -92,6 +100,8 @@ func Test_baseList_Strings(t *testing.T) {
 }
 
 func Test_list_Capacity(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseIList
@@ -112,6 +122,8 @@ func Test_list_Capacity(t *testing.T) {
 }
 
 func Test_list_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -131,6 +143,8 @@ func Test_list_Clone(t *testing.T) {
 }
 
 func Test_list_Get(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		l     baseList
@@ -152,6 +166,8 @@ func Test_list_Get(t *testing.T) {
 }
 
 func Test_list_Len(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -174,6 +190,8 @@ func Test_list_Len(t *testing.T) {
 }
 
 func Test_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		args    []int
@@ -209,6 +227,8 @@ func Test_CreateList(t *testing.T) {
 }
 
 func Test_list_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -234,6 +254,8 @@ func Test_list_Create(t *testing.T) {
 }
 
 func Test_list_New(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -258,6 +280,8 @@ func Test_list_New(t *testing.T) {
 }
 
 func Test_list_CreateDict(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		l       baseList
@@ -289,6 +313,8 @@ func Test_list_CreateDict(t *testing.T) {
 }
 
 func Test_list_Contains(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -312,6 +338,8 @@ func Test_list_Contains(t *testing.T) {
 }
 
 func Test_list_Without(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -335,6 +363,8 @@ func Test_list_Without(t *testing.T) {
 }
 
 func Test_list_Unique(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -354,6 +384,8 @@ func Test_list_Unique(t *testing.T) {
 	}
 }
 func Test_list_Reverse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    baseList
@@ -374,6 +406,8 @@ func Test_list_Reverse(t *testing.T) {
 }
 
 func Test_list_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		i int
 		v interface{}
@@ -423,6 +457,8 @@ var mapFixture = map[string]interface{}{
 var dictFixture = baseDict(baseDictHelper.AsDictionary(mapFixture).AsMap())
 
 func dumpKeys(t *testing.T, d1, d2 baseIDict) {
+	t.Parallel()
+
 	for key := range d1.AsMap() {
 		v1, v2 := d1.Get(key), d2.Get(key)
 		if reflect.DeepEqual(v1, v2) {
@@ -433,6 +469,8 @@ func dumpKeys(t *testing.T, d1, d2 baseIDict) {
 }
 
 func Test_dict_AsMap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    baseDict
@@ -452,6 +490,8 @@ func Test_dict_AsMap(t *testing.T) {
 }
 
 func Test_dict_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    baseDict
@@ -487,6 +527,8 @@ func Test_dict_Clone(t *testing.T) {
 }
 
 func Test_baseDict_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		d            baseDict
@@ -516,6 +558,8 @@ func Test_baseDict_CreateList(t *testing.T) {
 }
 
 func Test_dict_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		d       baseDict
@@ -547,6 +591,8 @@ func Test_dict_Create(t *testing.T) {
 }
 
 func Test_dict_Default(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key    interface{}
 		defVal interface{}
@@ -572,6 +618,8 @@ func Test_dict_Default(t *testing.T) {
 }
 
 func Test_dict_Delete(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key  interface{}
 		keys []interface{}
@@ -606,6 +654,8 @@ func Test_dict_Delete(t *testing.T) {
 }
 
 func Test_dict_Flush(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    baseDict
@@ -635,6 +685,8 @@ func Test_dict_Flush(t *testing.T) {
 }
 
 func Test_dict_Keys(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    baseDict
@@ -653,6 +705,8 @@ func Test_dict_Keys(t *testing.T) {
 }
 
 func Test_dict_KeysAsString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    baseDict
@@ -671,6 +725,8 @@ func Test_dict_KeysAsString(t *testing.T) {
 }
 
 func Test_dict_Merge(t *testing.T) {
+	t.Parallel()
+
 	adding1 := baseDict{
 		"int":        1000,
 		"Add1Int":    1,
@@ -716,6 +772,8 @@ func Test_dict_Merge(t *testing.T) {
 }
 
 func Test_dict_Values(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    baseDict
@@ -734,6 +792,8 @@ func Test_dict_Values(t *testing.T) {
 }
 
 func Test_dict_Add(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -759,6 +819,8 @@ func Test_dict_Add(t *testing.T) {
 }
 
 func Test_dict_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -783,6 +845,8 @@ func Test_dict_Set(t *testing.T) {
 }
 
 func Test_dict_Transpose(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    baseDict

--- a/collections/string_test.go
+++ b/collections/string_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestUnIndent(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		s string
 	}
@@ -47,6 +49,8 @@ func TestUnIndent(t *testing.T) {
 }
 
 func TestString_ToTitle(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		s    String
 		want string
@@ -63,6 +67,8 @@ func TestString_ToTitle(t *testing.T) {
 }
 
 func TestWrapString(t *testing.T) {
+	t.Parallel()
+
 	sample := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 	tests := []struct {
 		s          string
@@ -90,6 +96,8 @@ func TestWrapString(t *testing.T) {
 }
 
 func TestString_FindWord(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		pos    int
 		accept []string
@@ -129,6 +137,8 @@ func TestString_FindWord(t *testing.T) {
 }
 
 func TestString_FindContext(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		pos   int
 		left  string
@@ -169,6 +179,8 @@ func TestString_FindContext(t *testing.T) {
 }
 
 func TestString_Protect(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      String
 		want      String
@@ -204,6 +216,8 @@ func TestString_Protect(t *testing.T) {
 }
 
 func TestString_ParseBool(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		value String
 		want  bool

--- a/context.go
+++ b/context.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,8 +12,6 @@ import (
 )
 
 func createContext(varsFiles []string, namedVars []string) (context collections.IDictionary) {
-	context = collections.CreateDictionary()
-
 	type fileDef struct {
 		name    string
 		value   interface{}
@@ -102,6 +101,10 @@ func createContext(varsFiles []string, namedVars []string) (context collections.
 		}
 
 		if loader == nil {
+			if context == nil {
+				// The context is not initialized yet, so we create it with the default collection type
+				context = collections.CreateDictionary()
+			}
 			context.Set(nv.name, nv.value)
 			continue
 		}
@@ -109,12 +112,18 @@ func createContext(varsFiles []string, namedVars []string) (context collections.
 		if err != nil {
 			errors.Raise("Error %v while loading vars file %s", nv.value, err)
 		}
+		if context == nil {
+			// The context is not initialized yet, so we create it with the same type of the
+			// first file argument
+			context = content.Create()
+		}
 		for key, value := range content.AsMap() {
 			context.Set(key, value)
 		}
 	}
 
 	if len(unnamed) > 0 {
+		fmt.Printf("3 Adding %[1]s = %[2]v (%[2]T)\n", "ARGS", unnamed)
 		context.Set("ARGS", unnamed)
 	}
 	return

--- a/hcl/generated_test.go
+++ b/hcl/generated_test.go
@@ -16,6 +16,8 @@ import (
 var strFixture = hclList(hclListHelper.NewStringList(strings.Split("Hello World, I'm Foo Bar!", " ")...).AsArray())
 
 func Test_list_Append(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      hclIList
@@ -37,6 +39,8 @@ func Test_list_Append(t *testing.T) {
 }
 
 func Test_list_Prepend(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      hclIList
@@ -58,6 +62,8 @@ func Test_list_Prepend(t *testing.T) {
 }
 
 func Test_list_AsArray(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -77,6 +83,8 @@ func Test_list_AsArray(t *testing.T) {
 }
 
 func Test_HclList_Strings(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -96,6 +104,8 @@ func Test_HclList_Strings(t *testing.T) {
 }
 
 func Test_list_Capacity(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclIList
@@ -116,6 +126,8 @@ func Test_list_Capacity(t *testing.T) {
 }
 
 func Test_list_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -135,6 +147,8 @@ func Test_list_Clone(t *testing.T) {
 }
 
 func Test_list_Get(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		l     hclList
@@ -156,6 +170,8 @@ func Test_list_Get(t *testing.T) {
 }
 
 func Test_list_Len(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -178,6 +194,8 @@ func Test_list_Len(t *testing.T) {
 }
 
 func Test_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		args    []int
@@ -213,6 +231,8 @@ func Test_CreateList(t *testing.T) {
 }
 
 func Test_list_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -238,6 +258,8 @@ func Test_list_Create(t *testing.T) {
 }
 
 func Test_list_New(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -262,6 +284,8 @@ func Test_list_New(t *testing.T) {
 }
 
 func Test_list_CreateDict(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		l       hclList
@@ -293,6 +317,8 @@ func Test_list_CreateDict(t *testing.T) {
 }
 
 func Test_list_Contains(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -316,6 +342,8 @@ func Test_list_Contains(t *testing.T) {
 }
 
 func Test_list_Without(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -339,6 +367,8 @@ func Test_list_Without(t *testing.T) {
 }
 
 func Test_list_Unique(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -358,6 +388,8 @@ func Test_list_Unique(t *testing.T) {
 	}
 }
 func Test_list_Reverse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -378,6 +410,8 @@ func Test_list_Reverse(t *testing.T) {
 }
 
 func Test_list_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		i int
 		v interface{}
@@ -427,6 +461,8 @@ var mapFixture = map[string]interface{}{
 var dictFixture = hclDict(hclDictHelper.AsDictionary(mapFixture).AsMap())
 
 func dumpKeys(t *testing.T, d1, d2 hclIDict) {
+	t.Parallel()
+
 	for key := range d1.AsMap() {
 		v1, v2 := d1.Get(key), d2.Get(key)
 		if reflect.DeepEqual(v1, v2) {
@@ -437,6 +473,8 @@ func dumpKeys(t *testing.T, d1, d2 hclIDict) {
 }
 
 func Test_dict_AsMap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    hclDict
@@ -456,6 +494,8 @@ func Test_dict_AsMap(t *testing.T) {
 }
 
 func Test_dict_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    hclDict
@@ -491,6 +531,8 @@ func Test_dict_Clone(t *testing.T) {
 }
 
 func Test_HclDict_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		d            hclDict
@@ -520,6 +562,8 @@ func Test_HclDict_CreateList(t *testing.T) {
 }
 
 func Test_dict_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		d       hclDict
@@ -551,6 +595,8 @@ func Test_dict_Create(t *testing.T) {
 }
 
 func Test_dict_Default(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key    interface{}
 		defVal interface{}
@@ -576,6 +622,8 @@ func Test_dict_Default(t *testing.T) {
 }
 
 func Test_dict_Delete(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key  interface{}
 		keys []interface{}
@@ -610,6 +658,8 @@ func Test_dict_Delete(t *testing.T) {
 }
 
 func Test_dict_Flush(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    hclDict
@@ -639,6 +689,8 @@ func Test_dict_Flush(t *testing.T) {
 }
 
 func Test_dict_Keys(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    hclDict
@@ -657,6 +709,8 @@ func Test_dict_Keys(t *testing.T) {
 }
 
 func Test_dict_KeysAsString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    hclDict
@@ -675,6 +729,8 @@ func Test_dict_KeysAsString(t *testing.T) {
 }
 
 func Test_dict_Merge(t *testing.T) {
+	t.Parallel()
+
 	adding1 := hclDict{
 		"int":        1000,
 		"Add1Int":    1,
@@ -720,6 +776,8 @@ func Test_dict_Merge(t *testing.T) {
 }
 
 func Test_dict_Values(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    hclDict
@@ -738,6 +796,8 @@ func Test_dict_Values(t *testing.T) {
 }
 
 func Test_dict_Add(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -763,6 +823,8 @@ func Test_dict_Add(t *testing.T) {
 }
 
 func Test_dict_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -787,6 +849,8 @@ func Test_dict_Set(t *testing.T) {
 }
 
 func Test_dict_Transpose(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    hclDict

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func Test_list_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    hclList
@@ -29,6 +31,8 @@ func Test_list_String(t *testing.T) {
 }
 
 func Test_dict_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    hclDict
@@ -48,6 +52,8 @@ func Test_dict_String(t *testing.T) {
 }
 
 func TestMarshalHCLVars(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		Name  string `hcl:",omitempty"`
 		Value int    `hcl:",omitempty"`
@@ -75,6 +81,12 @@ func TestMarshalHCLVars(t *testing.T) {
 		{"Null value", args{nil, noIndent}, "null"},
 		{"Null struct", args{testNilPtr, noIndent}, "null"},
 		{"List of integer", args{[]int{0, 1, 2, 3}, noIndent}, "[0,1,2,3]"},
+		{"One level map", args{hclDict{"a": hclDict{"b": 10}}, noIndent}, "a {b=10}"},
+		{"One level map (pretty)", args{hclDict{"a": hclDict{"b": 10}}, indent}, "a {\n  b = 10\n}"},
+		{"Two level map 1", args{hclDict{"a": hclDict{"b": hclDict{"c": 10, "d": 20}}}, noIndent}, "a b {c=10 d=20}"},
+		{"Two level map 1 (pretty)", args{hclDict{"a": hclDict{"b": hclDict{"c": 10, "d": 20}}}, indent}, "a b {\n  c = 10\n  d = 20\n}"},
+		{"Two level map 2", args{hclDict{"a": hclDict{"b": hclDict{"c": 10, "d": 20}}, "e": 30}, noIndent}, "a b {c=10 d=20} e=30"},
+		{"Two level map 2 (pretty)", args{hclDict{"a": hclDict{"b": hclDict{"c": 10, "d": 20}}, "e": 30}, indent}, "e = 30\n\na b {\n  c = 10\n  d = 20\n}"},
 		{"Map", args{hclDict{"a": 0, "bb": 1}, noIndent}, "a=0 bb=1"},
 		{"Map (pretty)", args{hclDict{"a": 0, "bb": 1}, indent}, "a  = 0\nbb = 1"},
 		{"Structure (pretty)", args{test{"name", 1}, indent}, "Name  = \"name\"\nValue = 1"},
@@ -93,6 +105,8 @@ func TestMarshalHCLVars(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		hcl     string
@@ -120,6 +134,8 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestUnmarshalStrict(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		hcl     string

--- a/hcl/utilities.go
+++ b/hcl/utilities.go
@@ -189,8 +189,11 @@ func marshalHCL(value interface{}, fullHcl, head bool, prefix, indent string) (r
 					items = append(items, strings.Replace(rendered, specialFormat, id(key), -1))
 
 				} else {
-					if indent == "" && strings.HasPrefix(rendered, `"`) && equal == "" {
-						keyLen = len(id(key)) + 1
+					if indent == "" {
+						keyLen = 0
+						if equal == "" && !strings.HasPrefix(rendered, `{`) {
+							keyLen = len(id(key)) + 1
+						}
 					}
 					items = append(items, fmt.Sprintf("%*s%s%s", -keyLen, id(key), equal, rendered))
 				}

--- a/json/generated_test.go
+++ b/json/generated_test.go
@@ -16,6 +16,8 @@ import (
 var strFixture = jsonList(jsonListHelper.NewStringList(strings.Split("Hello World, I'm Foo Bar!", " ")...).AsArray())
 
 func Test_list_Append(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      jsonIList
@@ -37,6 +39,8 @@ func Test_list_Append(t *testing.T) {
 }
 
 func Test_list_Prepend(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      jsonIList
@@ -58,6 +62,8 @@ func Test_list_Prepend(t *testing.T) {
 }
 
 func Test_list_AsArray(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -77,6 +83,8 @@ func Test_list_AsArray(t *testing.T) {
 }
 
 func Test_JsonList_Strings(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -96,6 +104,8 @@ func Test_JsonList_Strings(t *testing.T) {
 }
 
 func Test_list_Capacity(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonIList
@@ -116,6 +126,8 @@ func Test_list_Capacity(t *testing.T) {
 }
 
 func Test_list_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -135,6 +147,8 @@ func Test_list_Clone(t *testing.T) {
 }
 
 func Test_list_Get(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		l     jsonList
@@ -156,6 +170,8 @@ func Test_list_Get(t *testing.T) {
 }
 
 func Test_list_Len(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -178,6 +194,8 @@ func Test_list_Len(t *testing.T) {
 }
 
 func Test_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		args    []int
@@ -213,6 +231,8 @@ func Test_CreateList(t *testing.T) {
 }
 
 func Test_list_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -238,6 +258,8 @@ func Test_list_Create(t *testing.T) {
 }
 
 func Test_list_New(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -262,6 +284,8 @@ func Test_list_New(t *testing.T) {
 }
 
 func Test_list_CreateDict(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		l       jsonList
@@ -293,6 +317,8 @@ func Test_list_CreateDict(t *testing.T) {
 }
 
 func Test_list_Contains(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -316,6 +342,8 @@ func Test_list_Contains(t *testing.T) {
 }
 
 func Test_list_Without(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -339,6 +367,8 @@ func Test_list_Without(t *testing.T) {
 }
 
 func Test_list_Unique(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -358,6 +388,8 @@ func Test_list_Unique(t *testing.T) {
 	}
 }
 func Test_list_Reverse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    jsonList
@@ -378,6 +410,8 @@ func Test_list_Reverse(t *testing.T) {
 }
 
 func Test_list_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		i int
 		v interface{}
@@ -427,6 +461,8 @@ var mapFixture = map[string]interface{}{
 var dictFixture = jsonDict(jsonDictHelper.AsDictionary(mapFixture).AsMap())
 
 func dumpKeys(t *testing.T, d1, d2 jsonIDict) {
+	t.Parallel()
+
 	for key := range d1.AsMap() {
 		v1, v2 := d1.Get(key), d2.Get(key)
 		if reflect.DeepEqual(v1, v2) {
@@ -437,6 +473,8 @@ func dumpKeys(t *testing.T, d1, d2 jsonIDict) {
 }
 
 func Test_dict_AsMap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    jsonDict
@@ -456,6 +494,8 @@ func Test_dict_AsMap(t *testing.T) {
 }
 
 func Test_dict_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    jsonDict
@@ -491,6 +531,8 @@ func Test_dict_Clone(t *testing.T) {
 }
 
 func Test_JsonDict_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		d            jsonDict
@@ -520,6 +562,8 @@ func Test_JsonDict_CreateList(t *testing.T) {
 }
 
 func Test_dict_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		d       jsonDict
@@ -551,6 +595,8 @@ func Test_dict_Create(t *testing.T) {
 }
 
 func Test_dict_Default(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key    interface{}
 		defVal interface{}
@@ -576,6 +622,8 @@ func Test_dict_Default(t *testing.T) {
 }
 
 func Test_dict_Delete(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key  interface{}
 		keys []interface{}
@@ -610,6 +658,8 @@ func Test_dict_Delete(t *testing.T) {
 }
 
 func Test_dict_Flush(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    jsonDict
@@ -639,6 +689,8 @@ func Test_dict_Flush(t *testing.T) {
 }
 
 func Test_dict_Keys(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    jsonDict
@@ -657,6 +709,8 @@ func Test_dict_Keys(t *testing.T) {
 }
 
 func Test_dict_KeysAsString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    jsonDict
@@ -675,6 +729,8 @@ func Test_dict_KeysAsString(t *testing.T) {
 }
 
 func Test_dict_Merge(t *testing.T) {
+	t.Parallel()
+
 	adding1 := jsonDict{
 		"int":        1000,
 		"Add1Int":    1,
@@ -720,6 +776,8 @@ func Test_dict_Merge(t *testing.T) {
 }
 
 func Test_dict_Values(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    jsonDict
@@ -738,6 +796,8 @@ func Test_dict_Values(t *testing.T) {
 }
 
 func Test_dict_Add(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -763,6 +823,8 @@ func Test_dict_Add(t *testing.T) {
 }
 
 func Test_dict_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -787,6 +849,8 @@ func Test_dict_Set(t *testing.T) {
 }
 
 func Test_dict_Transpose(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    jsonDict

--- a/template/extra_data_test.go
+++ b/template/extra_data_test.go
@@ -11,7 +11,6 @@ import (
 
 func Test_Data(t *testing.T) {
 	template := MustNewTemplate("", nil, "", nil)
-
 	tests := []struct {
 		name    string
 		test    string
@@ -40,7 +39,6 @@ func Test_Data(t *testing.T) {
 
 func Test_YAML(t *testing.T) {
 	template := MustNewTemplate("", nil, "", nil)
-
 	tests := []struct {
 		name    string
 		test    string
@@ -67,7 +65,6 @@ func Test_YAML(t *testing.T) {
 
 func Test_HCL(t *testing.T) {
 	template := MustNewTemplate("", nil, "", nil)
-
 	tests := []struct {
 		name    string
 		test    string

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func Test_getTargetFile(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		fileName   string
 		sourcePath string
@@ -29,6 +31,8 @@ func Test_getTargetFile(t *testing.T) {
 }
 
 func Test_templateWithErrors(t *testing.T) {
+	t.Parallel()
+
 	template, _ := NewTemplate(".", nil, "", nil)
 	tests := []struct {
 		name    string

--- a/xml/generated_test.go
+++ b/xml/generated_test.go
@@ -16,6 +16,8 @@ import (
 var strFixture = xmlList(xmlListHelper.NewStringList(strings.Split("Hello World, I'm Foo Bar!", " ")...).AsArray())
 
 func Test_list_Append(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      xmlIList
@@ -37,6 +39,8 @@ func Test_list_Append(t *testing.T) {
 }
 
 func Test_list_Prepend(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      xmlIList
@@ -58,6 +62,8 @@ func Test_list_Prepend(t *testing.T) {
 }
 
 func Test_list_AsArray(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -77,6 +83,8 @@ func Test_list_AsArray(t *testing.T) {
 }
 
 func Test_XmlList_Strings(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -96,6 +104,8 @@ func Test_XmlList_Strings(t *testing.T) {
 }
 
 func Test_list_Capacity(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlIList
@@ -116,6 +126,8 @@ func Test_list_Capacity(t *testing.T) {
 }
 
 func Test_list_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -135,6 +147,8 @@ func Test_list_Clone(t *testing.T) {
 }
 
 func Test_list_Get(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		l     xmlList
@@ -156,6 +170,8 @@ func Test_list_Get(t *testing.T) {
 }
 
 func Test_list_Len(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -178,6 +194,8 @@ func Test_list_Len(t *testing.T) {
 }
 
 func Test_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		args    []int
@@ -213,6 +231,8 @@ func Test_CreateList(t *testing.T) {
 }
 
 func Test_list_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -238,6 +258,8 @@ func Test_list_Create(t *testing.T) {
 }
 
 func Test_list_New(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -262,6 +284,8 @@ func Test_list_New(t *testing.T) {
 }
 
 func Test_list_CreateDict(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		l       xmlList
@@ -293,6 +317,8 @@ func Test_list_CreateDict(t *testing.T) {
 }
 
 func Test_list_Contains(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -316,6 +342,8 @@ func Test_list_Contains(t *testing.T) {
 }
 
 func Test_list_Without(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -339,6 +367,8 @@ func Test_list_Without(t *testing.T) {
 }
 
 func Test_list_Unique(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -358,6 +388,8 @@ func Test_list_Unique(t *testing.T) {
 	}
 }
 func Test_list_Reverse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    xmlList
@@ -378,6 +410,8 @@ func Test_list_Reverse(t *testing.T) {
 }
 
 func Test_list_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		i int
 		v interface{}
@@ -427,6 +461,8 @@ var mapFixture = map[string]interface{}{
 var dictFixture = xmlDict(xmlDictHelper.AsDictionary(mapFixture).AsMap())
 
 func dumpKeys(t *testing.T, d1, d2 xmlIDict) {
+	t.Parallel()
+
 	for key := range d1.AsMap() {
 		v1, v2 := d1.Get(key), d2.Get(key)
 		if reflect.DeepEqual(v1, v2) {
@@ -437,6 +473,8 @@ func dumpKeys(t *testing.T, d1, d2 xmlIDict) {
 }
 
 func Test_dict_AsMap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    xmlDict
@@ -456,6 +494,8 @@ func Test_dict_AsMap(t *testing.T) {
 }
 
 func Test_dict_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    xmlDict
@@ -491,6 +531,8 @@ func Test_dict_Clone(t *testing.T) {
 }
 
 func Test_XmlDict_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		d            xmlDict
@@ -520,6 +562,8 @@ func Test_XmlDict_CreateList(t *testing.T) {
 }
 
 func Test_dict_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		d       xmlDict
@@ -551,6 +595,8 @@ func Test_dict_Create(t *testing.T) {
 }
 
 func Test_dict_Default(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key    interface{}
 		defVal interface{}
@@ -576,6 +622,8 @@ func Test_dict_Default(t *testing.T) {
 }
 
 func Test_dict_Delete(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key  interface{}
 		keys []interface{}
@@ -610,6 +658,8 @@ func Test_dict_Delete(t *testing.T) {
 }
 
 func Test_dict_Flush(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    xmlDict
@@ -639,6 +689,8 @@ func Test_dict_Flush(t *testing.T) {
 }
 
 func Test_dict_Keys(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    xmlDict
@@ -657,6 +709,8 @@ func Test_dict_Keys(t *testing.T) {
 }
 
 func Test_dict_KeysAsString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    xmlDict
@@ -675,6 +729,8 @@ func Test_dict_KeysAsString(t *testing.T) {
 }
 
 func Test_dict_Merge(t *testing.T) {
+	t.Parallel()
+
 	adding1 := xmlDict{
 		"int":        1000,
 		"Add1Int":    1,
@@ -720,6 +776,8 @@ func Test_dict_Merge(t *testing.T) {
 }
 
 func Test_dict_Values(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    xmlDict
@@ -738,6 +796,8 @@ func Test_dict_Values(t *testing.T) {
 }
 
 func Test_dict_Add(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -763,6 +823,8 @@ func Test_dict_Add(t *testing.T) {
 }
 
 func Test_dict_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -787,6 +849,8 @@ func Test_dict_Set(t *testing.T) {
 }
 
 func Test_dict_Transpose(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    xmlDict

--- a/yaml/generated_test.go
+++ b/yaml/generated_test.go
@@ -16,6 +16,8 @@ import (
 var strFixture = yamlList(yamlListHelper.NewStringList(strings.Split("Hello World, I'm Foo Bar!", " ")...).AsArray())
 
 func Test_list_Append(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      yamlIList
@@ -37,6 +39,8 @@ func Test_list_Append(t *testing.T) {
 }
 
 func Test_list_Prepend(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		l      yamlIList
@@ -58,6 +62,8 @@ func Test_list_Prepend(t *testing.T) {
 }
 
 func Test_list_AsArray(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -77,6 +83,8 @@ func Test_list_AsArray(t *testing.T) {
 }
 
 func Test_YamlList_Strings(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -96,6 +104,8 @@ func Test_YamlList_Strings(t *testing.T) {
 }
 
 func Test_list_Capacity(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlIList
@@ -116,6 +126,8 @@ func Test_list_Capacity(t *testing.T) {
 }
 
 func Test_list_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -135,6 +147,8 @@ func Test_list_Clone(t *testing.T) {
 }
 
 func Test_list_Get(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		l     yamlList
@@ -156,6 +170,8 @@ func Test_list_Get(t *testing.T) {
 }
 
 func Test_list_Len(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -178,6 +194,8 @@ func Test_list_Len(t *testing.T) {
 }
 
 func Test_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		args    []int
@@ -213,6 +231,8 @@ func Test_CreateList(t *testing.T) {
 }
 
 func Test_list_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -238,6 +258,8 @@ func Test_list_Create(t *testing.T) {
 }
 
 func Test_list_New(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -262,6 +284,8 @@ func Test_list_New(t *testing.T) {
 }
 
 func Test_list_CreateDict(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		l       yamlList
@@ -293,6 +317,8 @@ func Test_list_CreateDict(t *testing.T) {
 }
 
 func Test_list_Contains(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -316,6 +342,8 @@ func Test_list_Contains(t *testing.T) {
 }
 
 func Test_list_Without(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -339,6 +367,8 @@ func Test_list_Without(t *testing.T) {
 }
 
 func Test_list_Unique(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -358,6 +388,8 @@ func Test_list_Unique(t *testing.T) {
 	}
 }
 func Test_list_Reverse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -378,6 +410,8 @@ func Test_list_Reverse(t *testing.T) {
 }
 
 func Test_list_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		i int
 		v interface{}
@@ -427,6 +461,8 @@ var mapFixture = map[string]interface{}{
 var dictFixture = yamlDict(yamlDictHelper.AsDictionary(mapFixture).AsMap())
 
 func dumpKeys(t *testing.T, d1, d2 yamlIDict) {
+	t.Parallel()
+
 	for key := range d1.AsMap() {
 		v1, v2 := d1.Get(key), d2.Get(key)
 		if reflect.DeepEqual(v1, v2) {
@@ -437,6 +473,8 @@ func dumpKeys(t *testing.T, d1, d2 yamlIDict) {
 }
 
 func Test_dict_AsMap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    yamlDict
@@ -456,6 +494,8 @@ func Test_dict_AsMap(t *testing.T) {
 }
 
 func Test_dict_Clone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    yamlDict
@@ -491,6 +531,8 @@ func Test_dict_Clone(t *testing.T) {
 }
 
 func Test_YamlDict_CreateList(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		d            yamlDict
@@ -520,6 +562,8 @@ func Test_YamlDict_CreateList(t *testing.T) {
 }
 
 func Test_dict_Create(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		d       yamlDict
@@ -551,6 +595,8 @@ func Test_dict_Create(t *testing.T) {
 }
 
 func Test_dict_Default(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key    interface{}
 		defVal interface{}
@@ -576,6 +622,8 @@ func Test_dict_Default(t *testing.T) {
 }
 
 func Test_dict_Delete(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key  interface{}
 		keys []interface{}
@@ -610,6 +658,8 @@ func Test_dict_Delete(t *testing.T) {
 }
 
 func Test_dict_Flush(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    yamlDict
@@ -639,6 +689,8 @@ func Test_dict_Flush(t *testing.T) {
 }
 
 func Test_dict_Keys(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    yamlDict
@@ -657,6 +709,8 @@ func Test_dict_Keys(t *testing.T) {
 }
 
 func Test_dict_KeysAsString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    yamlDict
@@ -675,6 +729,8 @@ func Test_dict_KeysAsString(t *testing.T) {
 }
 
 func Test_dict_Merge(t *testing.T) {
+	t.Parallel()
+
 	adding1 := yamlDict{
 		"int":        1000,
 		"Add1Int":    1,
@@ -720,6 +776,8 @@ func Test_dict_Merge(t *testing.T) {
 }
 
 func Test_dict_Values(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    yamlDict
@@ -738,6 +796,8 @@ func Test_dict_Values(t *testing.T) {
 }
 
 func Test_dict_Add(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -763,6 +823,8 @@ func Test_dict_Add(t *testing.T) {
 }
 
 func Test_dict_Set(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key interface{}
 		v   interface{}
@@ -787,6 +849,8 @@ func Test_dict_Set(t *testing.T) {
 }
 
 func Test_dict_Transpose(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    yamlDict

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func Test_list_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		l    yamlList
@@ -39,6 +41,8 @@ func Test_list_String(t *testing.T) {
 }
 
 func Test_dict_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		d    yamlDict
@@ -74,6 +78,8 @@ func Test_dict_String(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		yaml string
@@ -94,6 +100,8 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestUnmarshalWithError(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		yaml string
@@ -112,6 +120,8 @@ func TestUnmarshalWithError(t *testing.T) {
 }
 
 func TestUnmarshalStrict(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		yaml    string


### PR DESCRIPTION
- Run most of the tests in parallel
- Fix an Hcl rendering problem
