### PR TITLE
For retro-compatibility we add back support for old assignation mode

### DIFF
--- a/collections/string.go
+++ b/collections/string.go
@@ -310,7 +310,9 @@ func (s String) GetContextAtPosition(pos int, left, right string) (String, int) 
 		begin = strings.LastIndex(s[:pos].Str(), left)
 	}
 	if right != "" {
-		end = strings.Index(s[pos:].Str(), right) + pos + len(right)
+		if end = strings.Index(s[pos:].Str(), right); end >= 0 {
+			end += pos + len(right)
+		}
 	}
 	if begin < 0 || end < 0 {
 		return "", -1

--- a/collections/string_test.go
+++ b/collections/string_test.go
@@ -159,8 +159,8 @@ func TestString_FindContext(t *testing.T) {
 		{"A context (with (double level parenthesis))", args{22, "(", ")"}, "(double level parenthesis)", 16},
 		{"A context (with no bracket)", args{19, "[", "]"}, "", -1},
 		{"A context (with no enclosing context)", args{15, "", ""}, " ", 15},
-		// 123456789012345678901234567890123456789012345678901234567890
-		//          1         2         3         4         5         6
+		{"A context (outside of context)", args{1, "(", ")"}, "", -1},
+		{"(context) after", args{12, "(", ")"}, "", -1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.s.Str(), func(t *testing.T) {

--- a/docs/_functions.md
+++ b/docs/_functions.md
@@ -109,12 +109,13 @@ concat                  iif                     repeat                  ternary
 
 Runtime
 
-alias                   attributes              exit                    getSignature            run                     
-aliases                 categories              func                    include                 sign                    
-allFunctions            current                 function                localAlias              signature               
-assert                  ellipsis                functions               methods                 substitute              
-assertion               exec                    getAttributes           raise                   templateNames           
-attr                    execute                 getMethods              raiseError              templates               
+alias                   attr                    exit                    include                 signature               
+aliases                 attributes              func                    localAlias              substitute              
+allFunctions            categories              function                methods                 templateNames           
+assert                  current                 functions               raise                   templates               
+assertWarning           ellipsis                getAttributes           raiseError              
+assertion               exec                    getMethods              run                     
+assertw                 execute                 getSignature            sign                    
 
 Sprig Cryptographic & Security http://masterminds.github.io/sprig/crypto.html
 

--- a/docs/doc_test/assignation.razor
+++ b/docs/doc_test/assignation.razor
@@ -7,14 +7,14 @@
 
 | Razor expression                            | Go Template                                              | Note
 | ----------------                            | -----------                                              | ----
-| `{{- assert (isNil $.string) "$.string has already been declared, use = to overwrite existing value" }}{{- set $ "string" "string value" }}`                | `{{- set $ "string" "string value" }}`                   | Global assignation of string
-| `{{- assert (isNil $.numeric1) "$.numeric1 has already been declared, use = to overwrite existing value" }}{{- set $ "numeric1" 10 }}`                          | `{{- set $ "numeric1" 10 }}`                             | Global assignation of integer
-| `{{- assert (isNil $.numeric2) "$.numeric2 has already been declared, use = to overwrite existing value" }}{{- set $ "numeric2" 1.23 }}`                        | `{{- set $ "numeric2" 1.23 }}`                           | Global assignation of floating point
-| `{{- assert (isNil $.numeric3) "$.numeric3 has already been declared, use = to overwrite existing value" }}{{- set $ "numeric3" 4E+4 }}`                        | `{{- set $ "numeric3" 4E+4 }}`                           | Global assignation of large scientific notation number
-| `{{- assert (isNil $.numeric4) "$.numeric4 has already been declared, use = to overwrite existing value" }}{{- set $ "numeric4" 5E-3 }}`                        | `{{- set $ "numeric4" 5E-3 }}`                           | Global assignation of small scientific notation number
-| `{{- assert (isNil $.hexa1) "$.hexa1 has already been declared, use = to overwrite existing value" }}{{- set $ "hexa1" 0x100 }}`                          | `{{- set $ "hexa1" 0x100 }}`                             | Global assignation of hexadecimal number
-| `{{- assert (isNil $.result1) "$.result1 has already been declared, use = to overwrite existing value" }}{{- set $ "result1" (mul (add 2 3) 4) }}`                      | `{{- set $ "result1" (mul (add 2 3) 4) }}`               | Global assignation of mathematic expression
-| `{{- assert (isNil $.result2) "$.result2 has already been declared, use = to overwrite existing value" }}{{- set $ "result2" ((String "hello world!").Title) }}` | `{{- set $ "result2" ((String "hello world!").Title) }}` | Global assignation of generic expression
+| `{{- assertWarning (isNil $.string) "$.string has already been declared, use = to overwrite existing value" }}{{- set $ "string" "string value" }}`                | `{{- set $ "string" "string value" }}`                   | Global assignation of string
+| `{{- assertWarning (isNil $.numeric1) "$.numeric1 has already been declared, use = to overwrite existing value" }}{{- set $ "numeric1" 10 }}`                          | `{{- set $ "numeric1" 10 }}`                             | Global assignation of integer
+| `{{- assertWarning (isNil $.numeric2) "$.numeric2 has already been declared, use = to overwrite existing value" }}{{- set $ "numeric2" 1.23 }}`                        | `{{- set $ "numeric2" 1.23 }}`                           | Global assignation of floating point
+| `{{- assertWarning (isNil $.numeric3) "$.numeric3 has already been declared, use = to overwrite existing value" }}{{- set $ "numeric3" 4E+4 }}`                        | `{{- set $ "numeric3" 4E+4 }}`                           | Global assignation of large scientific notation number
+| `{{- assertWarning (isNil $.numeric4) "$.numeric4 has already been declared, use = to overwrite existing value" }}{{- set $ "numeric4" 5E-3 }}`                        | `{{- set $ "numeric4" 5E-3 }}`                           | Global assignation of small scientific notation number
+| `{{- assertWarning (isNil $.hexa1) "$.hexa1 has already been declared, use = to overwrite existing value" }}{{- set $ "hexa1" 0x100 }}`                          | `{{- set $ "hexa1" 0x100 }}`                             | Global assignation of hexadecimal number
+| `{{- assertWarning (isNil $.result1) "$.result1 has already been declared, use = to overwrite existing value" }}{{- set $ "result1" (mul (add 2 3) 4) }}`                      | `{{- set $ "result1" (mul (add 2 3) 4) }}`               | Global assignation of mathematic expression
+| `{{- assertWarning (isNil $.result2) "$.result2 has already been declared, use = to overwrite existing value" }}{{- set $ "result2" ((String "hello world!").Title) }}` | `{{- set $ "result2" ((String "hello world!").Title) }}` | Global assignation of generic expression
 
 ## Local variables
 

--- a/docs/doc_test/collections.razor
+++ b/docs/doc_test/collections.razor
@@ -7,11 +7,11 @@
 
 | Razor                                           | Gotemplate                                          | Note
 | ---                                             | ---                                                 | ---
-| `{{- assert (isNil $.razorDict) "$.razorDict has already been declared, use = to overwrite existing value" }}{{- set $ "razorDict" (dict "test" 1 "test2" 2) }}`    | `{{- set $ "goDict" (dict "test" 1 "test2" 2) }}`   | Creation
-| `{{- assert (isNil $.razorDict2) "$.razorDict2 has already been declared, use = to overwrite existing value" }}{{- set $ "razorDict2" (dict "test3" 3 "test5" 5) }}`  | `{{- set $ "goDict2" (dict "test3" 3 "test5" 5) }}` | Creation
+| `{{- assertWarning (isNil $.razorDict) "$.razorDict has already been declared, use = to overwrite existing value" }}{{- set $ "razorDict" (dict "test" 1 "test2" 2) }}`    | `{{- set $ "goDict" (dict "test" 1 "test2" 2) }}`   | Creation
+| `{{- assertWarning (isNil $.razorDict2) "$.razorDict2 has already been declared, use = to overwrite existing value" }}{{- set $ "razorDict2" (dict "test3" 3 "test5" 5) }}`  | `{{- set $ "goDict2" (dict "test3" 3 "test5" 5) }}` | Creation
 | `{{ set .razorDict "test2" 3 }}`                 | `{{- set .goDict "test2" 3 }}`                      | Update
 | `{{ set .razorDict "test3" 4 }}`                 | `{{- set .goDict "test3" 4 }}`                      | Update 
-| `{{- assert (not (isNil $.razorDict)) "$.razorDict does not exist, use := to declare new variable" }}{{- set $ "razorDict" (merge $.razorDict $.razorDict2) }}`    | `{{- set $ "goDict" (merge .goDict .goDict2) }}`    | Merge (First dict has priority)
+| `{{- assertWarning (not (isNil $.razorDict)) "$.razorDict does not exist, use := to declare new variable" }}{{- set $ "razorDict" (merge $.razorDict $.razorDict2) }}`    | `{{- set $ "goDict" (merge .goDict .goDict2) }}`    | Merge (First dict has priority)
 | `{{ $.razorDict.test3 }}`                             | `{{ $.goDict.test3 }}`                              | Should be `4`
 | `{{ $.razorDict.test5 }}`                             | `{{ $.goDict.test5 }}`                              | Should be `5`
 | `{{ extract $.razorDict "test" "test3" "undef" }}`          | `{{ extract $.goDict "test" "test3" "undef" }}`     | Extract values, should be `[1,4,null]`
@@ -51,9 +51,9 @@
 
 | Razor                                            | Gotemplate                                             | Note
 | ---                                              | ---                                                    | ---
-| `{{- assert (isNil $.razorList) "$.razorList has already been declared, use = to overwrite existing value" }}{{- set $ "razorList" (list "test1" "test2" "test3") }}` | `{{- set $ "goList" (list "test1" "test2" "test3") }}` | Creation
-| `{{- assert (not (isNil $.razorList)) "$.razorList does not exist, use := to declare new variable" }}{{- set $ "razorList" (append $.razorList "test4") }}`       | `{{- set $ "goList" (append .goList "test4") }}`       | Append
-| `{{- assert (not (isNil $.razorList)) "$.razorList does not exist, use := to declare new variable" }}{{- set $ "razorList" (prepend $.razorList "test0") }}`      | `{{- set $ "goList" (prepend .goList "test0") }}`      | Prepend
+| `{{- assertWarning (isNil $.razorList) "$.razorList has already been declared, use = to overwrite existing value" }}{{- set $ "razorList" (list "test1" "test2" "test3") }}` | `{{- set $ "goList" (list "test1" "test2" "test3") }}` | Creation
+| `{{- assertWarning (not (isNil $.razorList)) "$.razorList does not exist, use := to declare new variable" }}{{- set $ "razorList" (append $.razorList "test4") }}`       | `{{- set $ "goList" (append .goList "test4") }}`       | Append
+| `{{- assertWarning (not (isNil $.razorList)) "$.razorList does not exist, use := to declare new variable" }}{{- set $ "razorList" (prepend $.razorList "test0") }}`      | `{{- set $ "goList" (prepend .goList "test0") }}`      | Prepend
 | `{{ $.razorList }}`                                    | `{{ $.goList }}`                                       | Should be `["test0","test1","test2","test3","test4"]`
 | `{{ contains $.razorList "test1" "test2" }}`        | `{{- contains .goList "test1" "test2" }}`              | Check if element is in list
 | `{{ has "test1" $.razorList }}`                      | `{{- has "test1" .goList }}`                           | has is an alias to contains

--- a/docs/doc_test/comments.razor
+++ b/docs/doc_test/comments.razor
@@ -53,7 +53,7 @@ will give :
 ### Example with HCL code
 
 ```go
-{{- assert (isNil $.value) "$.value has already been declared, use = to overwrite existing value" }}{{- set $ "value" (add 2 (mul 8 15)) }}
+{{- assertWarning (isNil $.value) "$.value has already been declared, use = to overwrite existing value" }}{{- set $ "value" (add 2 (mul 8 15)) }}
 
 Str              = "string"
 Int              = 123

--- a/docs/doc_test/literals.razor
+++ b/docs/doc_test/literals.razor
@@ -11,8 +11,8 @@ But it you type something like `{{ $.john.doe }}{{ $.company.com }}`, it will tr
 The result would be `<no value><no value>` unless you have defined:
 
 ```go
-{{- assert (isNil $.john) "$.john has already been declared, use = to overwrite existing value" }}{{- set $ "john" (data "doe = 123.45") }}
-{{- assert (isNil $.company) "$.company has already been declared, use = to overwrite existing value" }}{{- set $ "company" (data "com = {{ $.Math.Pi }}") }}
+{{- assertWarning (isNil $.john) "$.john has already been declared, use = to overwrite existing value" }}{{- set $ "john" (data "doe = 123.45") }}
+{{- assertWarning (isNil $.company) "$.company has already been declared, use = to overwrite existing value" }}{{- set $ "company" (data "com = {{ $.Math.Pi }}") }}
 ```
 
 In that case, the result of `{{ $.john.doe }}{{ $.company.com }}` will be `123.453.141592653589793`.
@@ -39,7 +39,7 @@ The `{{ "expression" }}` will keep the spaces before and after expression as the
 
 With razor, assignation and flow control expression (if, else, elseif, end, range, with, etc.) will render go template code with - on left side.
 
-`{{- assert (isNil $.expr) "$.expr has already been declared, use = to overwrite existing value" }}{{- set $ "expr" "expression" }}` => `{{- set $ "expr" "expression" }}`
+`{{- assertWarning (isNil $.expr) "$.expr has already been declared, use = to overwrite existing value" }}{{- set $ "expr" "expression" }}` => `{{- set $ "expr" "expression" }}`
 
 But for variables, you have to specify the expected behavior.
 

--- a/docs/doc_test/templates.razor
+++ b/docs/doc_test/templates.razor
@@ -29,7 +29,7 @@
 ## Using templates
 
 ```
-  {{- assert (isNil $.values) "$.values has already been declared, use = to overwrite existing value" }}{{- set $ "values" (data (`{"var1": "Test", "var2": ["Test1", "Test2"]}`)) }}
+  {{- assertWarning (isNil $.values) "$.values has already been declared, use = to overwrite existing value" }}{{- set $ "values" (data (`{"var1": "Test", "var2": ["Test1", "Test2"]}`)) }}
 ```
 
 | Razor | Gotemplate

--- a/docs/functions_long.md
+++ b/docs/functions_long.md
@@ -464,84 +464,50 @@ func Fir(size int, bg string, fg string, char string, reverse bool) interface{},
 
 ```go
 // Logs a message using CRITICAL as log level (0).
+// Aliases: criticalf
 func critical(args ...interface{}) string
 ```
 
 ```go
-// Logs a message with format string using CRITICAL as log level (0).
-func criticalf(format string, args ...interface{}) string
-```
-
-```go
 // Logs a message using DEBUG as log level (5).
+// Aliases: debugf
 func debug(args ...interface{}) string
 ```
 
 ```go
-// Logs a message with format using DEBUG as log level (5).
-func debugf(format string, args ...interface{}) string
-```
-
-```go
 // Logs a message using ERROR as log level (1).
+// Aliases: errorf
 func error(args ...interface{}) string
 ```
 
 ```go
-// Logs a message with format using ERROR as log level (1).
-func errorf(format string, args ...interface{}) string
-```
-
-```go
 // Equivalents to critical followed by a call to os.Exit(1).
+// Aliases: fatalf
 func fatal(args ...interface{}) string
 ```
 
 ```go
-// Equivalents to criticalf followed by a call to os.Exit(1).
-func fatalf(format string, args ...interface{}) string
-```
-
-```go
 // Logs a message using INFO as log level (4).
+// Aliases: infof
 func info(args ...interface{}) string
 ```
 
 ```go
-// Logs a message with format using INFO as log level (4).
-func infof(format string, args ...interface{}) string
-```
-
-```go
 // Logs a message using NOTICE as log level (3).
+// Aliases: noticef
 func notice(args ...interface{}) string
 ```
 
 ```go
-// Logs a message with format using NOTICE as log level (3).
-func noticef(format string, args ...interface{}) string
-```
-
-```go
 // Equivalents to critical followed by a call to panic.
+// Aliases: panicf
 func panic(args ...interface{}) string
 ```
 
 ```go
-// Equivalents to criticalf followed by a call to panic.
-func panicf(format string, args ...interface{}) string
-```
-
-```go
 // Logs a message using WARNING as log level (2).
-// Aliases: warn
+// Aliases: warn, warnf, warningf
 func warning(args ...interface{}) string
-```
-
-```go
-// Logs a message with format using WARNING as log level (2).
-// Aliases: warnf
-func warningf(format string, args ...interface{}) string
 ```
 ### Mathematic Bit Operations
 
@@ -1392,6 +1358,12 @@ func assert(test interface{}, message ...interface{}) string, error
 ```
 
 ```go
+// Issues a formated warning if the test condition is false.
+// Aliases: assertw
+func assertWarning(test interface{}, message ...interface{}) string
+```
+
+```go
 // Returns all functions group by categories.
 // 
 // The returned value has the following properties:
@@ -1476,7 +1448,7 @@ func localAlias(name string, function string, source interface{}, args ...interf
 ```go
 // Raise a formated error.
 // Aliases: raiseError
-func raise(message interface{}, arguments ...interface{}) string, error
+func raise(args ...interface{}) string, error
 ```
 
 ```go

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is initialized at build time through -ldflags "-X main.Version=<version number>"
-var version = "2.6.2"
+var version = "2.6.3"
 var tempFolder = errors.Must(ioutil.TempDir("", "gotemplate-")).(string)
 
 const (

--- a/template/extra_logging.go
+++ b/template/extra_logging.go
@@ -16,74 +16,47 @@ const (
 )
 
 var loggingFuncs = dictionary{
-	"critical":  func(args ...interface{}) string { return logBase(Log.Critical, args...) },
-	"criticalf": func(format string, args ...interface{}) string { return logBasef(Log.Criticalf, format, args...) },
-	"debug":     func(args ...interface{}) string { return logBase(Log.Debug, args...) },
-	"debugf":    func(format string, args ...interface{}) string { return logBasef(Log.Debugf, format, args...) },
-	"error":     func(args ...interface{}) string { return logBase(Log.Error, args...) },
-	"errorf":    func(format string, args ...interface{}) string { return logBasef(Log.Errorf, format, args...) },
-	"fatal":     func(args ...interface{}) string { return logBase(Log.Fatal, args...) },
-	"fatalf":    func(format string, args ...interface{}) string { return logBasef(Log.Fatalf, format, args...) },
-	"info":      func(args ...interface{}) string { return logBase(Log.Info, args...) },
-	"infof":     func(format string, args ...interface{}) string { return logBasef(Log.Infof, format, args...) },
-	"notice":    func(args ...interface{}) string { return logBase(Log.Notice, args...) },
-	"noticef":   func(format string, args ...interface{}) string { return logBasef(Log.Noticef, format, args...) },
-	"panic":     func(args ...interface{}) string { return logBase(Log.Panic, args...) },
-	"panicf":    func(format string, args ...interface{}) string { return logBasef(Log.Panicf, format, args...) },
-	"warning":   func(args ...interface{}) string { return logBase(Log.Warning, args...) },
-	"warningf":  func(format string, args ...interface{}) string { return logBasef(Log.Warningf, format, args...) },
-}
-
-var loggingFuncsArgs = arguments{
-	"criticalf": {"format", "args"},
-	"debugf":    {"format", "args"},
-	"errorf":    {"format", "args"},
-	"fatalf":    {"format", "args"},
-	"infof":     {"format", "args"},
-	"noticef":   {"format", "args"},
-	"panicf":    {"format", "args"},
-	"warningf":  {"format", "args"},
+	"critical": func(args ...interface{}) string { return logBase(Log.Critical, args...) },
+	"debug":    func(args ...interface{}) string { return logBase(Log.Debug, args...) },
+	"error":    func(args ...interface{}) string { return logBase(Log.Error, args...) },
+	"fatal":    func(args ...interface{}) string { return logBase(Log.Fatal, args...) },
+	"info":     func(args ...interface{}) string { return logBase(Log.Info, args...) },
+	"notice":   func(args ...interface{}) string { return logBase(Log.Notice, args...) },
+	"panic":    func(args ...interface{}) string { return logBase(Log.Panic, args...) },
+	"warning":  func(args ...interface{}) string { return logBase(Log.Warning, args...) },
 }
 
 var loggingFuncsAliases = aliases{
-	"warning":  {"warn"},
-	"warningf": {"warnf"},
+	"critical": {"criticalf"},
+	"debug":    {"debugf"},
+	"error":    {"errorf"},
+	"fatal":    {"fatalf"},
+	"info":     {"infof"},
+	"notice":   {"noticef"},
+	"panic":    {"panicf"},
+	"warning":  {"warn", "warnf", "warningf"},
 }
 
 var loggingFuncsHelp = descriptions{
-	"critical":  "Logs a message using CRITICAL as log level (0).",
-	"criticalf": "Logs a message with format string using CRITICAL as log level (0).",
-	"debug":     "Logs a message using DEBUG as log level (5).",
-	"debugf":    "Logs a message with format using DEBUG as log level (5).",
-	"error":     "Logs a message using ERROR as log level (1).",
-	"errorf":    "Logs a message with format using ERROR as log level (1).",
-	"fatal":     "Equivalents to critical followed by a call to os.Exit(1).",
-	"fatalf":    "Equivalents to criticalf followed by a call to os.Exit(1).",
-	"info":      "Logs a message using INFO as log level (4).",
-	"infof":     "Logs a message with format using INFO as log level (4).",
-	"notice":    "Logs a message using NOTICE as log level (3).",
-	"noticef":   "Logs a message with format using NOTICE as log level (3).",
-	"panic":     "Equivalents to critical followed by a call to panic.",
-	"panicf":    "Equivalents to criticalf followed by a call to panic.",
-	"warning":   "Logs a message using WARNING as log level (2).",
-	"warningf":  "Logs a message with format using WARNING as log level (2).",
+	"critical": "Logs a message using CRITICAL as log level (0).",
+	"debug":    "Logs a message using DEBUG as log level (5).",
+	"error":    "Logs a message using ERROR as log level (1).",
+	"fatal":    "Equivalents to critical followed by a call to os.Exit(1).",
+	"info":     "Logs a message using INFO as log level (4).",
+	"notice":   "Logs a message using NOTICE as log level (3).",
+	"panic":    "Equivalents to critical followed by a call to panic.",
+	"warning":  "Logs a message using WARNING as log level (2).",
 }
 
 func (t *Template) addLoggingFuncs() {
 	t.AddFunctions(loggingFuncs, loggingBase, FuncOptions{
 		FuncHelp:    loggingFuncsHelp,
-		FuncArgs:    loggingFuncsArgs,
 		FuncAliases: loggingFuncsAliases,
 	})
 }
 
 func logBase(f func(...interface{}), args ...interface{}) string {
-	f(args...)
-	return ""
-}
-
-func logBasef(f func(string, ...interface{}), format string, args ...interface{}) string {
-	f(format, args...)
+	f(utils.FormatMessage(args...))
 	return ""
 }
 

--- a/template/template.go
+++ b/template/template.go
@@ -39,6 +39,8 @@ const (
 	EnvSubstitutes   = "GOTEMPLATE_SUBSTITUTES"
 	EnvDebug         = "GOTEMPLATE_DEBUG"
 	EnvExtensionPath = "GOTEMPLATE_PATH"
+	// TODO: Deprecated, to remove in future version
+	EnvDeprecatedAssign = "GOTEMPLATE_DEPRECATED_ASSIGN"
 )
 
 // Common variables

--- a/utils/color.go
+++ b/utils/color.go
@@ -130,16 +130,24 @@ func SprintColor(args ...interface{}) (string, error) {
 	}
 
 	c, _ := Color(colorArgs...)
+	return c.Sprint(FormatMessage(args[i:]...)), nil
+}
 
-	var format string
-	if i < len(args) {
-		format = fmt.Sprint(args[i])
+// FormatMessage analyses the arguments to determine if printf or println should be used.
+func FormatMessage(args ...interface{}) string {
+	switch len(args) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprint(args[0])
+	default:
+		if format, args := fmt.Sprint(args[0]), args[1:]; strings.Contains(format, "%") {
+			if result := fmt.Sprintf(format, args...); !strings.Contains(result, "%!") {
+				return result
+			}
+		}
+		return strings.TrimSuffix(fmt.Sprintln(args...), EOL)
 	}
-
-	if strings.Contains(format, "%") {
-		return c.Sprintf(format, args[i+1:]...), nil
-	}
-	return c.Sprint(strings.TrimSuffix(fmt.Sprintln(args[i:]...), EOL)), nil
 }
 
 var nameValues map[string]color.Attribute

--- a/utils/color_test.go
+++ b/utils/color_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestColor(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		args    []string
 		want    *color.Color
@@ -25,6 +26,29 @@ func TestColor(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Color() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		args []interface{}
+		want string
+	}{
+		{"No argument", nil, ""},
+		{"Empty arguments", []interface{}{}, ""},
+		{"Single argument", []interface{}{"Hello"}, "Hello"},
+		{"Two arguments", []interface{}{"Hello", "World"}, "Hello World"},
+		{"Two arguments with format", []interface{}{"Hello %s! %d", "World", 100}, "Hello World! 100"},
+		{"Bad format", []interface{}{"Hello %s! %d", "World"}, "Hello %s! %d World"},
+		{"Escaped %", []interface{}{"You got %d%% off", 60}, "You got 60% off"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatMessage(tt.args...); got != tt.want {
+				t.Errorf("FormatMessage() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- To avoid breaking change, we simply issue warning instead of completely remove the functionality
- The old assignation mode could be disabled by setting GOTEMPLATE_DEPRECATED_ASSIGN=1
