### PR TITLE
Implement flexible error managment

### DIFF
--- a/docs/_usage.md
+++ b/docs/_usage.md
@@ -6,41 +6,42 @@ An extended template processor for go.
 See: https://github.com/coveo/gotemplate/blob/master/README.md for complete documentation.
 
 Flags:
-  -h, --help                   Show context-sensitive help (also try --help-long and --help-man).
-      --color                  Force rendering of colors event if output is redirected
-      --no-color               Force rendering of colors event if output is redirected
-  -v, --version                Get the current version of gotemplate
-      --base                   Turn off all extensions (they could then be enabled explicitly)
-      --razor                  Option Razor, on by default, --no-razor to disable
-      --extension              Option Extension, on by default, --no-extension to disable
-      --math                   Option Math, on by default, --no-math to disable
-      --sprig                  Option Sprig, on by default, --no-sprig to disable
-      --data                   Option Data, on by default, --no-data to disable
-      --logging                Option Logging, on by default, --no-logging to disable
-      --runtime                Option Runtime, on by default, --no-runtime to disable
-      --utils                  Option Utils, on by default, --no-utils to disable
-      --net                    Option Net, on by default, --no-net to disable
-      --os                     Option OS, on by default, --no-os to disable
-      --delimiters={{,}},@     Define the default delimiters for go template (separate the left, right and razor delimiters by a comma) (--del)
-  -i, --import=file ...        Import variables files (could be any of YAML, JSON or HCL format)
-  -V, --var=values ...         Import named variables (if value is a file, the content is loaded)
-  -p, --patterns=pattern ...   Additional patterns that should be processed by gotemplate
-  -e, --exclude=pattern ...    Exclude file patterns (comma separated) when applying gotemplate recursively
-  -o, --overwrite              Overwrite file instead of renaming them if they exist (required only if source folder is the same as the target folder)
-  -s, --substitute=exp ...     Substitute text in the processed files by applying the regex substitute expression (format: /regex/substitution, the first character acts as separator like in sed, see: Go regexp) or specify that value through
-                               GOTEMPLATE_SUBSTITUTES where each substitute is separated by a newline
-  -r, --recursive              Process all template files recursively
-  -R, --recursion-depth=depth  Process template files recursively specifying depth
-      --source=folder          Specify a source folder (default to the current folder)
-      --target=folder          Specify a target folder (default to source folder)
-  -I, --stdin                  Force read of the standard input to get a template definition (useful only if GOTEMPLATE_NO_STDIN is set)
-  -f, --follow-symlinks        Follow the symbolic links while using the recursive option
-  -P, --print                  Output the result directly to stdout
-  -d, --disable                Disable go template rendering (used to view razor conversion)
-      --accept-no-value        Do not consider rendering <no value> as an error (--nv) or env: GOTEMPLATE_NO_VALUE
-      --debug-log-level=level  Set the debug logging level 0-9 (--dl) or env: GOTEMPLATE_DEBUG
-  -L, --log-level=level        Set the logging level 0-9 (--ll)
-      --log-simple             Disable the extended logging, i.e. no color, no date (--ls)
+  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
+      --color                    Force rendering of colors event if output is redirected
+      --no-color                 Force rendering of colors event if output is redirected
+  -v, --version                  Get the current version of gotemplate
+      --base                     Turn off all extensions (they could then be enabled explicitly)
+      --razor                    Option Razor, on by default, --no-razor to disable
+      --extension                Option Extension, on by default, --no-extension to disable
+      --math                     Option Math, on by default, --no-math to disable
+      --sprig                    Option Sprig, on by default, --no-sprig to disable
+      --data                     Option Data, on by default, --no-data to disable
+      --logging                  Option Logging, on by default, --no-logging to disable
+      --runtime                  Option Runtime, on by default, --no-runtime to disable
+      --utils                    Option Utils, on by default, --no-utils to disable
+      --net                      Option Net, on by default, --no-net to disable
+      --os                       Option OS, on by default, --no-os to disable
+      --delimiters={{,}},@       Define the default delimiters for go template (separate the left, right and razor delimiters by a comma) (--del)
+  -i, --import=file ...          Import variables files (could be any of YAML, JSON or HCL format)
+  -V, --var=values ...           Import named variables (if value is a file, the content is loaded)
+  -p, --patterns=pattern ...     Additional patterns that should be processed by gotemplate
+  -e, --exclude=pattern ...      Exclude file patterns (comma separated) when applying gotemplate recursively
+  -o, --overwrite                Overwrite file instead of renaming them if they exist (required only if source folder is the same as the target folder)
+  -s, --substitute=exp ...       Substitute text in the processed files by applying the regex substitute expression (format: /regex/substitution, the first character acts as separator like in sed, see: Go regexp) or specify that value through
+                                 GOTEMPLATE_SUBSTITUTES where each substitute is separated by a newline
+  -r, --recursive                Process all template files recursively
+  -R, --recursion-depth=depth    Process template files recursively specifying depth
+      --source=folder            Specify a source folder (default to the current folder)
+      --target=folder            Specify a target folder (default to source folder)
+  -I, --stdin                    Force read of the standard input to get a template definition (useful only if GOTEMPLATE_NO_STDIN is set)
+  -f, --follow-symlinks          Follow the symbolic links while using the recursive option
+  -P, --print                    Output the result directly to stdout
+  -d, --disable                  Disable go template rendering (used to view razor conversion)
+      --accept-no-value          Do not consider rendering <no value> as an error (--nv) or env: GOTEMPLATE_NO_VALUE
+  -S, --strict-error-validation  Consider error encountered in any file as real error (--strict) or env: GOTEMPLATE_STRICT_ERROR
+      --debug-log-level=level    Set the debug logging level 0-9 (--dl) or env: GOTEMPLATE_DEBUG
+  -L, --log-level=level          Set the logging level 0-9 (--ll)
+      --log-simple               Disable the extended logging, i.e. no color, no date (--ls)
 
 Args:
   [<templates>]  Template files or commands to process
@@ -52,26 +53,27 @@ Commands:
 
   run [<flags>] [<templates>...]
 
-        --delimiters={{,}},@     Define the default delimiters for go template (separate the left, right and razor delimiters by a comma) (--del)
-    -i, --import=file ...        Import variables files (could be any of YAML, JSON or HCL format)
-    -V, --var=values ...         Import named variables (if value is a file, the content is loaded)
-    -p, --patterns=pattern ...   Additional patterns that should be processed by gotemplate
-    -e, --exclude=pattern ...    Exclude file patterns (comma separated) when applying gotemplate recursively
-    -o, --overwrite              Overwrite file instead of renaming them if they exist (required only if source folder is the same as the target folder)
-    -s, --substitute=exp ...     Substitute text in the processed files by applying the regex substitute expression (format: /regex/substitution, the first character acts as separator like in sed, see: Go regexp) or specify that value through
-                                 GOTEMPLATE_SUBSTITUTES where each substitute is separated by a newline
-    -r, --recursive              Process all template files recursively
-    -R, --recursion-depth=depth  Process template files recursively specifying depth
-        --source=folder          Specify a source folder (default to the current folder)
-        --target=folder          Specify a target folder (default to source folder)
-    -I, --stdin                  Force read of the standard input to get a template definition (useful only if GOTEMPLATE_NO_STDIN is set)
-    -f, --follow-symlinks        Follow the symbolic links while using the recursive option
-    -P, --print                  Output the result directly to stdout
-    -d, --disable                Disable go template rendering (used to view razor conversion)
-        --accept-no-value        Do not consider rendering <no value> as an error (--nv) or env: GOTEMPLATE_NO_VALUE
-        --debug-log-level=level  Set the debug logging level 0-9 (--dl) or env: GOTEMPLATE_DEBUG
-    -L, --log-level=level        Set the logging level 0-9 (--ll)
-        --log-simple             Disable the extended logging, i.e. no color, no date (--ls)
+        --delimiters={{,}},@       Define the default delimiters for go template (separate the left, right and razor delimiters by a comma) (--del)
+    -i, --import=file ...          Import variables files (could be any of YAML, JSON or HCL format)
+    -V, --var=values ...           Import named variables (if value is a file, the content is loaded)
+    -p, --patterns=pattern ...     Additional patterns that should be processed by gotemplate
+    -e, --exclude=pattern ...      Exclude file patterns (comma separated) when applying gotemplate recursively
+    -o, --overwrite                Overwrite file instead of renaming them if they exist (required only if source folder is the same as the target folder)
+    -s, --substitute=exp ...       Substitute text in the processed files by applying the regex substitute expression (format: /regex/substitution, the first character acts as separator like in sed, see: Go regexp) or specify that value through
+                                   GOTEMPLATE_SUBSTITUTES where each substitute is separated by a newline
+    -r, --recursive                Process all template files recursively
+    -R, --recursion-depth=depth    Process template files recursively specifying depth
+        --source=folder            Specify a source folder (default to the current folder)
+        --target=folder            Specify a target folder (default to source folder)
+    -I, --stdin                    Force read of the standard input to get a template definition (useful only if GOTEMPLATE_NO_STDIN is set)
+    -f, --follow-symlinks          Follow the symbolic links while using the recursive option
+    -P, --print                    Output the result directly to stdout
+    -d, --disable                  Disable go template rendering (used to view razor conversion)
+        --accept-no-value          Do not consider rendering <no value> as an error (--nv) or env: GOTEMPLATE_NO_VALUE
+    -S, --strict-error-validation  Consider error encountered in any file as real error (--strict) or env: GOTEMPLATE_STRICT_ERROR
+        --debug-log-level=level    Set the debug logging level 0-9 (--dl) or env: GOTEMPLATE_DEBUG
+    -L, --log-level=level          Set the logging level 0-9 (--ll)
+        --log-simple               Disable the extended logging, i.e. no color, no date (--ls)
 
   list [<flags>] [<filters>...]
     Get detailed help on gotemplate functions

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 		print            = run.Flag("print", "Output the result directly to stdout").Short('P').Bool()
 		disableRender    = run.Flag("disable", "Disable go template rendering (used to view razor conversion)").Short('d').Bool()
 		acceptNoValue    = run.Flag("accept-no-value", "Do not consider rendering <no value> as an error (--nv) or env: "+template.EnvAcceptNoValue).Bool()
+		strictError      = run.Flag("strict-error-validation", "Consider error encountered in any file as real error (--strict) or env: "+template.EnvStrictErrorCheck).Short('S').Bool()
 		debugLogLevel    = run.Flag("debug-log-level", "Set the debug logging level 0-9 (--dl) or env: "+template.EnvDebug).Default("2").PlaceHolder("level").Int8()
 		logLevel         = run.Flag("log-level", "Set the logging level 0-9 (--ll)").Short('L').PlaceHolder("level").Int8()
 		logSimple        = run.Flag("log-simple", "Disable the extended logging, i.e. no color, no date (--ls)").Bool()
@@ -93,6 +94,7 @@ func main() {
 	app.Flag("ls", "short version of --log-simple").Hidden().BoolVar(logSimple)
 	app.Flag("del", "short version of --delimiters").Hidden().StringVar(delimiters)
 	app.Flag("nv", "short version of --accept-no-value").Hidden().BoolVar(acceptNoValue)
+	app.Flag("strict", "short version of --strict-error-validation").Hidden().BoolVar(strictError)
 
 	// Set the options for the available options (most of them are on by default)
 	optionsOff := app.Flag("base", "Turn off all extensions (they could then be enabled explicitly)").Bool()
@@ -162,6 +164,7 @@ func main() {
 	optionsSet[template.Overwrite] = *overwrite
 	optionsSet[template.OutputStdout] = *print
 	optionsSet[template.AcceptNoValue] = *acceptNoValue
+	optionsSet[template.StrictErrorCheck] = *strictError
 	for i := range options {
 		optionsSet[template.Options(i)] = options[i]
 	}

--- a/template/options.go
+++ b/template/options.go
@@ -23,6 +23,7 @@ const (
 	OutputStdout
 	RenderingDisabled
 	AcceptNoValue
+	StrictErrorCheck
 )
 
 // DefaultOptions returns a OptionsSet with the first options turned on by default

--- a/template/template.go
+++ b/template/template.go
@@ -35,12 +35,19 @@ type Template struct {
 
 // Environment variables that could be defined to override default behaviors.
 const (
-	EnvAcceptNoValue = "GOTEMPLATE_NO_VALUE"
-	EnvSubstitutes   = "GOTEMPLATE_SUBSTITUTES"
-	EnvDebug         = "GOTEMPLATE_DEBUG"
-	EnvExtensionPath = "GOTEMPLATE_PATH"
+	EnvAcceptNoValue    = "GOTEMPLATE_NO_VALUE"
+	EnvStrictErrorCheck = "GOTEMPLATE_STRICT_ERROR"
+	EnvSubstitutes      = "GOTEMPLATE_SUBSTITUTES"
+	EnvDebug            = "GOTEMPLATE_DEBUG"
+	EnvExtensionPath    = "GOTEMPLATE_PATH"
 	// TODO: Deprecated, to remove in future version
 	EnvDeprecatedAssign = "GOTEMPLATE_DEPRECATED_ASSIGN"
+)
+
+const (
+	noGoTemplate       = "no-gotemplate!"
+	noRazor            = "no-razor!"
+	explicitGoTemplate = "gotemplate!"
 )
 
 // Common variables
@@ -49,6 +56,7 @@ var (
 	ExtensionDepth = 2
 	toStrings      = collections.ToStrings
 	acceptNoValue  = String(os.Getenv(EnvAcceptNoValue)).ParseBool()
+	strictError    = String(os.Getenv(EnvStrictErrorCheck)).ParseBool()
 	Print          = utils.ColorPrint
 	Printf         = utils.ColorPrintf
 	Println        = utils.ColorPrintln
@@ -77,6 +85,9 @@ func NewTemplate(folder string, context interface{}, delimiters string, options 
 	t.options = iif(options != nil, options, DefaultOptions()).(OptionsSet)
 	if acceptNoValue {
 		t.options[AcceptNoValue] = true
+	}
+	if strictError {
+		t.options[StrictErrorCheck] = true
 	}
 	t.optionsEnabled = make(OptionsSet)
 	t.folder, _ = filepath.Abs(iif(folder != "", folder, utils.Pwd()).(string))
@@ -146,12 +157,12 @@ func (t Template) GetNewContext(folder string, useCache bool) *Template {
 
 // IsCode determines if the supplied code appears to have gotemplate code.
 func (t Template) IsCode(code string) bool {
-	return t.IsRazor(code) || strings.Contains(code, t.LeftDelim()) || strings.Contains(code, t.RightDelim())
+	return !strings.Contains(code, noGoTemplate) && (t.IsRazor(code) || strings.Contains(code, t.LeftDelim()) || strings.Contains(code, t.RightDelim()))
 }
 
 // IsRazor determines if the supplied code appears to have Razor code.
 func (t Template) IsRazor(code string) bool {
-	return strings.Contains(code, t.RazorDelim())
+	return strings.Contains(code, t.RazorDelim()) && !strings.Contains(code, noGoTemplate) && !strings.Contains(code, noRazor)
 }
 
 // LeftDelim returns the left delimiter.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -34,6 +34,7 @@ func Test_templateWithErrors(t *testing.T) {
 	t.Parallel()
 
 	template, _ := NewTemplate(".", nil, "", nil)
+	template.SetOption(StrictErrorCheck, true)
 	tests := []struct {
 		name    string
 		content string


### PR DESCRIPTION
When an error occurs in a non explicit gotemplate file (file with .gt, .gte or .template extension), we may want to left the file unchanged and just log the error at INFO debug level without considering it as a real error.

It is possible to enforce strict validation through command line parameter --strict-error-validation or by setting environment variable GOTEMPLATE_STRICT_ERROR=1.

It is also possible to explicitly disable the go template processing by adding a tag anywhere in the file:
  no-gotemplate!
  no-razor!

or explicitly enable error check by adding:
  gotemplate!