### PR TITLE
Fix bug where a variable looks like a file but is not

### DIFF
--- a/context.go
+++ b/context.go
@@ -80,11 +80,11 @@ func createContext(varsFiles []string, namedVars []string, mode string, ignoreMi
 				// Finally, we just try to convert the data with the converted value
 				if err := collections.ConvertData(filename, &content); err != nil {
 					content = nv.value
-				} else if isFileErr {
-					return nil, loadErr
 				}
 
-				if nv.name == "" {
+				if nv.name == "" && isFileErr {
+					return nil, loadErr
+				} else if nv.name == "" {
 					unnamed = append(unnamed, content)
 					return nil, nil
 				}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -10,90 +11,162 @@ import (
 )
 
 func TestCli(t *testing.T) {
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
+	variableTempDir := must(ioutil.TempDir("", "gotemplate-test-variable")).(string)
+	defer os.RemoveAll(variableTempDir)
+	variableFile := path.Join(variableTempDir, "test.variables")
+	must(ioutil.WriteFile(variableFile, []byte("testInt = 5\ntestString = \"hello\"\ntestBool = true"), 0644))
 
-	tempDir := must(ioutil.TempDir("", "gotemplate-test")).(string)
-	templateFile := path.Join(tempDir, "test.template")
-	templateFileContent := []byte("{{ $var := add 3 2 }}{{ $var }}")
-	must(ioutil.WriteFile(templateFile, templateFileContent, 0644))
+	tests := []struct {
+		name           string
+		pipe           string
+		args           []string
+		template       string
+		expectedCode   int
+		expectedResult string
+	}{
+		{
+			name:           "No arguments",
+			args:           []string{},
+			template:       "{{ add 3 2 }}",
+			expectedCode:   0,
+			expectedResult: "5",
+		},
+		{
+			name:           "Integers",
+			args:           []string{"--var", "test1=3", "--var", "test2=7"},
+			template:       "{{ $var := add .test1 .test2 }}{{ $var }}",
+			expectedCode:   0,
+			expectedResult: "10",
+		},
+		{
+			name:           "Import variables",
+			args:           []string{"--import", variableFile, "--var", "test1=3"},
+			template:       "{{ $var := add .test1 .testInt }}{{ $var }}",
+			expectedCode:   0,
+			expectedResult: "8",
+		},
+		{
+			name:           "STDIN variables",
+			pipe:           "testInt=3",
+			args:           []string{"-V-", "--var", "test2=4", "test.template"},
+			template:       "{{ $var := add .testInt .test2 }}{{ $var }}",
+			expectedCode:   0,
+			expectedResult: "7",
+		},
 
-	os.Args = []string{"gotemplate", "--source", tempDir}
-	exitCode := runGotemplate()
+		// Ambiguous variables
+		{
+			name:           "Variables that may look like filenames",
+			args:           []string{"--var", "test1=2.3.4", "--var", "test2=/var/path/literal"},
+			template:       "{{ print .test1 \"-\" .test2 }}",
+			expectedCode:   0,
+			expectedResult: "2.3.4-/var/path/literal",
+		},
+		{
+			name:           "Variable file as var",
+			args:           []string{"--var", "testFile=" + variableFile},
+			template:       "{{ print .testFile.testInt \"-\" .testFile.testString }}",
+			expectedCode:   0,
+			expectedResult: "5-hello",
+		},
+		{
+			name:           "Literal existing file name",
+			args:           []string{"--var", fmt.Sprintf("testFile='%s'", variableFile)},
+			template:       "{{ print .testFile }}",
+			expectedCode:   0,
+			expectedResult: variableFile,
+		},
 
-	assert.Equal(t, 0, exitCode)
-	readTemplateFileContent := must(ioutil.ReadFile(templateFile)).([]byte)
-	assert.Equal(t, templateFileContent, readTemplateFileContent)
-	generatedFile := path.Join(tempDir, "test.generated")
-	readGeneratedFileContent := must(ioutil.ReadFile(generatedFile)).([]byte)
-	assert.Equal(t, []byte("5"), readGeneratedFileContent)
-}
+		// Missing source
+		{
+			name:         "Non-existing source",
+			args:         []string{"--source", "/path/that/does/not/exist"},
+			expectedCode: 1,
+		},
+		{
+			name:         "Non-existing source (Ignored)",
+			args:         []string{"--source", "/path/that/does/not/exist", "--ignore-missing-source"},
+			expectedCode: 0,
+		},
+		{
+			name:         "Non-existing source (Ignored2)",
+			args:         []string{"--source", "/path/that/does/not/exist", "--ignore-missing-paths"},
+			expectedCode: 0,
+		},
 
-func TestErrorRecovery(t *testing.T) {
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
+		// Missing import
+		{
+			name:         "Non-existing import",
+			args:         []string{"--import", "/path/that/does/not/exist"},
+			expectedCode: 1,
+		},
+		{
+			name:         "Non-existing import (Ignored)",
+			args:         []string{"--import", "/path/that/does/not/exist", "--ignore-missing-import"},
+			expectedCode: 0,
+		},
+		{
+			name:         "Non-existing import (Ignored2)",
+			args:         []string{"--import", "/path/that/does/not/exist", "--ignore-missing-paths"},
+			expectedCode: 0,
+		},
 
-	tempDir := must(ioutil.TempDir("", "gotemplate-test")).(string)
-	templateFile := path.Join(tempDir, "test.template")
-	templateFileContent := []byte("{{ panic `test string` }}")
-	must(ioutil.WriteFile(templateFile, templateFileContent, 0644))
+		// Errors
+		{
+			name:         "Error recovery",
+			args:         []string{},
+			template:     "{{ panic `test string` }}",
+			expectedCode: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tempDir string
 
-	os.Args = []string{"gotemplate", "--source", tempDir}
-	exitCode := runGotemplate()
+			// Change and revert (defer) os values
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			oldCw := must(os.Getwd()).(string)
+			defer os.Chdir(oldCw)
 
-	assert.Equal(t, -1, exitCode)
-}
+			if tt.pipe != "" {
+				content := []byte(tt.pipe)
+				tmpStdin := must(ioutil.TempFile("", "example")).(*os.File)
+				defer os.Remove(tmpStdin.Name())
+				must(tmpStdin.Write(content))
+				must(tmpStdin.Seek(0, 0))
 
-func TestCliNonExistingSource(t *testing.T) {
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
+				oldStdin := os.Stdin
+				defer func() {
+					tmpStdin.Close()
+					os.Stdin = oldStdin
+				}()
 
-	os.Args = []string{"gotemplate", "--source", "/path/that/does/not/exist"}
-	exitCode := runGotemplate()
-	assert.Equal(t, 1, exitCode)
+				os.Stdin = tmpStdin
+			}
 
-	os.Args = []string{"gotemplate", "--source", "/path/that/does/not/exist", "--ignore-missing-source"}
-	exitCode = runGotemplate()
-	assert.Equal(t, 0, exitCode)
+			if tt.template != "" {
+				// Create template
+				tempDir = must(ioutil.TempDir("", "gotemplate-test")).(string)
+				os.Chdir(tempDir)
+				defer os.RemoveAll(tempDir)
+				templateFile := path.Join(tempDir, "test.template")
+				must(ioutil.WriteFile(templateFile, []byte(tt.template), 0644))
+				os.Args = append([]string{"gotemplate", "--source", tempDir}, tt.args...)
+			} else {
+				os.Args = append([]string{"gotemplate"}, tt.args...)
+			}
 
-	os.Args = []string{"gotemplate", "--source", "/path/that/does/not/exist", "--ignore-missing-paths"}
-	exitCode = runGotemplate()
-	assert.Equal(t, 0, exitCode)
-}
+			// Run gotemplate
+			exitCode := runGotemplate()
 
-func TestCliNonExistingImport(t *testing.T) {
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
+			assert.Equal(t, tt.expectedCode, exitCode, "Bad exit code")
 
-	tempDir := must(ioutil.TempDir("", "gotemplate-test")).(string)
-	templateFile := path.Join(tempDir, "test.template")
-	templateFileContent := []byte("{{ $var := add 3 2 }}{{ $var }}")
-	must(ioutil.WriteFile(templateFile, templateFileContent, 0644))
-
-	// Regular variables
-	os.Args = []string{"gotemplate", "--var", "test=123", "--var", "test=`/path/that/does/not/exist.json`", "--source", tempDir}
-	exitCode := runGotemplate()
-	assert.Equal(t, 0, exitCode)
-
-	// Missing imports
-	os.Args = []string{"gotemplate", "--import", "/path/that/does/not/exist.json", "--source", tempDir}
-	exitCode = runGotemplate()
-	assert.Equal(t, 1, exitCode)
-
-	os.Args = []string{"gotemplate", "--var", "test=/path/that/does/not/exist.json", "--source", tempDir}
-	exitCode = runGotemplate()
-	assert.Equal(t, 1, exitCode)
-
-	// Ignored missing imports
-	os.Args = []string{"gotemplate", "--import", "/path/that/does/not/exist.json", "--ignore-missing-import", "--source", tempDir}
-	exitCode = runGotemplate()
-	assert.Equal(t, 0, exitCode)
-
-	os.Args = []string{"gotemplate", "--import", "/path/that/does/not/exist.json", "--ignore-missing-paths", "--source", tempDir}
-	exitCode = runGotemplate()
-	assert.Equal(t, 0, exitCode)
-
-	os.Args = []string{"gotemplate", "--var", "test=/path/that/does/not/exist.json", "--ignore-missing-import", "--source", tempDir}
-	exitCode = runGotemplate()
-	assert.Equal(t, 0, exitCode)
+			if tt.expectedResult != "" {
+				generatedFile := path.Join(tempDir, "test.generated")
+				readGeneratedFileContent := must(ioutil.ReadFile(generatedFile)).([]byte)
+				assert.Equal(t, []byte(tt.expectedResult), readGeneratedFileContent, "Bad generated content")
+			}
+		})
+	}
 }


### PR DESCRIPTION
The bug happened when you called gotemplate like this:
`gotemplate -var test=2.7.4` or `gotemplate -var filename=test.json`. Gotemplate would try to interpret the file and crash. 
What happens now is that the file is interpreted if it exists, otherwise the file name is written as a literal. To have a variable with a literal filename when the file exists (not interpreted) you can call gotemplate like this:
`gotemplate -var filename='exists.json'`