### PR TITLE
Increase non-breaking error level

### DIFF
--- a/template/template_process.go
+++ b/template/template_process.go
@@ -93,7 +93,7 @@ func (t Template) processContentInternal(originalContent, source string, origina
 				extension := filepath.Ext(source)
 				strictMode = strictMode || (extension != "" && strings.Contains(".gt,.gte,.template", extension))
 				if !(strictMode) {
-					Log.Noticef("Ignored gotemplate error in %s (file left unchanged):\n%s", color.CyanString(source), err.Error())
+					Log.Errorf("Ignored gotemplate error in %s (file left unchanged):\n%s", color.CyanString(source), err.Error())
 					result, err = originalContent, nil
 				}
 			}


### PR DESCRIPTION
If there is an error in a non explicit gotemplate file, we used to simply add a notice. But that often resulted in hidding the actual error, so we display it as an error, but still not breaking.