### PR TITLE
Fix problems when converting objects to go native representation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
-    "cSpell.words": [
-        "UUIDs",
+    "cSpell.ignoreWords": [
         "adipiscing",
         "amet",
         "awrap",
@@ -20,6 +19,8 @@
         "typeis",
         "unsplit",
         "uuid",
-        "uuidv"
+        "UUIDs",
+        "uuidv",
+        "warnf"
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 pre-commit:
 	go fmt ./...
-	go test ./...-count 1
+	go test ./... -count 1
 	./render-doc
 
 install:

--- a/collections/convert_data.go
+++ b/collections/convert_data.go
@@ -74,7 +74,7 @@ func LoadData(filename string, out interface{}) (err error) {
 
 // ToBash returns the bash 4 variable representation of value
 func ToBash(value interface{}) string {
-	return toBash(ToNativeRepresentation(value), 0)
+	return toBash(must(MarshalGo(value)), 0)
 }
 
 func toBash(value interface{}, level int) (result string) {
@@ -139,62 +139,84 @@ func toBash(value interface{}, level int) (result string) {
 	return fmt.Sprint(value)
 }
 
-// ToNativeRepresentation converts any object to native (literals, maps, slices)
-func ToNativeRepresentation(value interface{}) interface{} {
+// GoMarshaler is the interface that could be implemented on object that want to customize
+// the marshaling to a native go representation.
+type GoMarshaler interface {
+	MarshalGo(interface{}) (interface{}, error)
+}
+
+// MarshalGo converts any object to native go type (literals, maps, slices).
+func MarshalGo(value interface{}) (result interface{}, err error) {
 	if value == nil {
-		return nil
+		return
 	}
 
 	typ, val := reflect.TypeOf(value), reflect.ValueOf(value)
 	if typ.Kind() == reflect.Ptr {
 		if val.IsNil() {
-			return nil
+			return
 		}
 		val = val.Elem()
 		typ = val.Type()
 	}
+
+	if val.CanInterface() && val.Type().Implements(reflect.TypeOf((*GoMarshaler)(nil)).Elem()) {
+		// The object implement a custom marshaller, so we let it generate its stuff
+		return val.Interface().(GoMarshaler).MarshalGo(value)
+	}
+
 	switch typ.Kind() {
 	case reflect.String:
-		return val.String()
+		result = val.String()
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
-		return int(val.Int())
+		result = int(val.Int())
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
-		return uint(val.Uint())
+		result = uint(val.Uint())
 
 	case reflect.Int64:
-		return val.Int()
+		result = val.Int()
 
 	case reflect.Uint64:
-		return val.Uint()
+		result = val.Uint()
 
 	case reflect.Float32, reflect.Float64:
-		return val.Float()
+		result = val.Float()
 
 	case reflect.Bool:
-		return val.Bool()
+		result = val.Bool()
 
 	case reflect.Slice, reflect.Array:
-		result := make([]interface{}, val.Len())
-		for i := range result {
-			result[i] = ToNativeRepresentation(val.Index(i).Interface())
+		array := make([]interface{}, val.Len())
+		for i := range array {
+			if array[i], err = MarshalGo(val.Index(i).Interface()); err != nil {
+				return
+			}
 		}
-		if len(result) == 1 && reflect.TypeOf(result[0]).Kind() == reflect.Map {
+		if len(array) == 1 && reflect.TypeOf(array[0]).Kind() == reflect.Map {
 			// If the result is an array of one map, we just return the inner element
-			return result[0]
+			result = array[0]
+		} else {
+			result = array
 		}
-		return result
 
 	case reflect.Map:
-		result := make(map[string]interface{}, val.Len())
+		m := make(map[string]interface{}, val.Len())
 		for _, key := range val.MapKeys() {
-			result[fmt.Sprintf("%v", key)] = ToNativeRepresentation(val.MapIndex(key).Interface())
+			if m[fmt.Sprint(key)], err = MarshalGo(val.MapIndex(key).Interface()); err != nil {
+				return
+			}
 		}
-		return result
+		result = m
 
 	case reflect.Struct:
-		result := make(map[string]interface{}, typ.NumField())
+		m := make(map[string]interface{}, typ.NumField())
+
+		info, key, err := getTags(typ)
+		if err != nil {
+			return nil, err
+		}
 		for i := 0; i < typ.NumField(); i++ {
 			sf := typ.Field(i)
 			if sf.Anonymous {
@@ -215,42 +237,78 @@ func ToNativeRepresentation(value interface{}) interface{} {
 				// Ignore unexported non-embedded fields.
 				continue
 			}
-			tag := sf.Tag.Get("hcl")
-			if tag == "" {
-				// If there is no hcl specific tag, we rely on json tag if there is
-				tag = sf.Tag.Get("json")
-			}
-			if tag == "-" {
+
+			tag := info[i]
+			if tag.name == "-" || !IsExported(sf.Name) || tag.options["omitempty"] && IsEmptyValue(val.Field(i)) {
 				continue
+			} else if tag.name == "" {
+				tag.name = sf.Name
 			}
 
-			split := strings.Split(tag, ",")
-			name := split[0]
-			if name == "" {
-				name = sf.Name
-			}
-			options := make(map[string]bool, len(split[1:]))
-			for i := range split[1:] {
-				options[split[i+1]] = true
-			}
-
-			if !IsExported(sf.Name) || options["omitempty"] && IsEmptyValue(val.Field(i)) {
-				continue
-			}
-
-			if options["inline"] || options["squash"] {
-				for key, value := range ToNativeRepresentation(val.Field(i).Interface()).(map[string]interface{}) {
-					result[key] = value
+			if tag.options["inline"] || tag.options["squash"] {
+				if subMap, err := MarshalGo(val.Field(i).Interface()); err != nil {
+					return nil, err
+				} else if subMap, ok := subMap.(map[string]interface{}); ok {
+					for key, value := range subMap {
+						m[key] = value
+					}
+				} else {
+					return nil, fmt.Errorf("Cannot apply inline or squash to non struct on field '%s'", sf.Name)
 				}
 			} else {
-				result[name] = ToNativeRepresentation(val.Field(i).Interface())
+				if value, err = MarshalGo(val.Field(i).Interface()); err != nil {
+					return nil, err
+				}
+				v := reflect.ValueOf(value)
+				if IsEmptyValue(v) && (v.Kind() == reflect.Struct || v.Kind() == reflect.Map) && tag.options["omitempty"] {
+					continue
+				}
+				if key >= 0 {
+					m[val.Field(key).String()] = map[string]interface{}{tag.name: v.Interface()}
+				} else {
+					m[tag.name] = v.Interface()
+				}
 			}
 		}
-		return result
+		result = m
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown type %T %v : %v\n", value, typ.Kind(), value)
-		return fmt.Sprintf("%v", value)
+		result = fmt.Sprint(value)
 	}
+	return
+}
+
+type tagInfo struct {
+	name    string
+	options map[string]bool
+}
+
+func getTags(t reflect.Type) (result []tagInfo, key int, err error) {
+	key = -1
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		var tag string
+		for _, category := range []string{"hcl", "json", "yaml", "xml", "toml"} {
+			if value := sf.Tag.Get(category); value != "" {
+				tag = value
+				break
+			}
+		}
+
+		split := strings.Split(tag, ",")
+		options := make(map[string]bool, len(split[1:]))
+		for _, key := range split[1:] {
+			options[key] = true
+		}
+		if options["key"] {
+			if key != -1 {
+				err = fmt.Errorf("Multiple keys defined on struct '%s' ('%s' and '%s')", t.Name(), t.Field(key).Name, sf.Name)
+			}
+			key = i
+		}
+		result = append(result, tagInfo{split[0], options})
+	}
+	return
 }
 
 // IsExported reports whether the identifier is exported.

--- a/collections/convert_data_test.go
+++ b/collections/convert_data_test.go
@@ -2,13 +2,14 @@ package collections
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type dictionary = map[string]interface{}
 
-func TestToNativeRepresentation(t *testing.T) {
+func TestMarshalGo(t *testing.T) {
 	t.Parallel()
 
 	type SubStruct struct {
@@ -57,16 +58,9 @@ func TestToNativeRepresentation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ToNativeRepresentation(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ToNativeRepresentation()\ngot : %v\nwant: %v", got, tt.want)
-				for k, v := range tt.want.(dictionary) {
-					if reflect.DeepEqual(v, got.(dictionary)[k]) {
-						continue
-					}
-					t.Errorf("key %v: %T vs %T", k, v, got.(dictionary)[k])
-				}
-
-			}
+			got, err := MarshalGo(tt.args)
+			assert.Equal(t, tt.want, got)
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -84,39 +78,138 @@ func Test_quote(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := quote(tt.arg); got != tt.want {
-				t.Errorf("quote() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, quote(tt.arg))
 		})
 	}
 }
 
-func ExampleToNativeRepresentation() {
-	type Y struct {
-		S string `hcl:"string,omitempty"`
-	}
-	type X struct {
-		Y  `hcl:",squash"`
-		A  int     `hcl:"a,omitempty"`
-		PS *string `hcl:"string_pointer,omitempty"`
-		PB *bool   `hcl:"bool_pointer,omitempty"`
+// This object has only private attributes.
+type customMarshallStruct struct {
+	privateInteger int
+	privateString string
+	privateBoolPointer *bool
+}
+
+// MarshalGo implements a custom marshaler that allows the object to convert its private attributes.
+func (s customMarshallStruct) MarshalGo(v interface{}) (interface{}, error) {
+	return map[string]interface{}{
+		"int": s.privateInteger,
+		"string": s.privateString,
+		"bool": *s.privateBoolPointer,
+	}, nil
+}
+
+func Test_CustomMarshal(t *testing.T) {
+	b := true
+	e := customMarshallStruct{10, "Hello", &b}
+	converted, err := MarshalGo(e)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"int": 10, "string": "Hello", "bool": true}, converted)
+}
+
+func ExampleMarshalGo() {
+	type Struct struct {
+		Integer       int     `hcl:"int,omitempty"`
+		StringPointer *string `hcl:"string_pointer,omitempty"`
+		BoolPointer   *bool   `hcl:"bool_pointer,omitempty"`
 	}
 
-	var a X
-	fmt.Println(ToNativeRepresentation(a))
-	a.A = 10
-	fmt.Println(ToNativeRepresentation(a))
-	a.S = "Hello"
-	fmt.Println(ToNativeRepresentation(a))
-	x := "World"
-	a.PS = &x
-	b := false
-	a.PB = &b
-	fmt.Println(ToNativeRepresentation(a))
+	var main Struct
+
+	fmt.Println(MarshalGo(main))
+	main.Integer = 10
+	fmt.Println(MarshalGo(main))
+	word := "World"
+	main.StringPointer = &word
+	bool := false
+	main.BoolPointer = &bool
+	fmt.Println(MarshalGo(main))
 
 	// Output:
-	// map[]
-	// map[a:10]
-	// map[a:10 string:Hello]
-	// map[a:10 bool_pointer:false string:Hello string_pointer:World]
+	// map[] <nil>
+	// map[int:10] <nil>
+	// map[bool_pointer:false int:10 string_pointer:World] <nil>
+}
+
+func ExampleMarshalGo_withSubStruct() {
+	type WithoutStructTag struct {
+		String1 string
+	}
+
+	type WithStructTag struct {
+		String2 string `hcl:"string,omitempty"`
+	}
+
+	type MainStruct struct {
+		WithoutStructTag
+		WithStructTag `hcl:",squash"`
+		Omit          WithStructTag `hcl:",omitempty"`
+		Integer       int           `hcl:"int,omitempty"`
+	}
+
+	var main MainStruct
+
+	main.Integer = 10
+	fmt.Println(MarshalGo(main))
+	main.String1 = "Hello"
+	main.String2 = "World"
+	fmt.Println(MarshalGo(main))
+
+	// Output:
+	// map[WithoutStructTag:map[String1:] int:10] <nil>
+	// map[WithoutStructTag:map[String1:Hello] int:10 string:World] <nil>
+}
+
+func ExampleMarshalGo_withList() {
+	type Element struct {
+		Name  string
+		Value int
+	}
+
+	type Struct struct {
+		Elements []Element `hcl:"elements,omitempty"`
+	}
+
+	var main Struct
+	main.Elements = []Element{{"value1", 1}, {"value2", 2}, {"value3", 3}}
+	fmt.Println(MarshalGo(main))
+
+	// Output:
+	// map[elements:[map[Name:value1 Value:1] map[Name:value2 Value:2] map[Name:value3 Value:3]]] <nil>
+}
+
+func ExampleMarshalGo_withKey() {
+	type Element struct {
+		Name  string `hcl:",key"`
+		Value int    `hcl:"value"`
+	}
+
+	type Struct struct {
+		Elements []Element `hcl:"elements,omitempty"`
+	}
+
+	var main Struct
+	main.Elements = []Element{{"v1", 1}, {"v2", 2}, {"v3", 3}}
+	fmt.Println(MarshalGo(main))
+
+	// Output:
+	// map[elements:[map[v1:map[value:1]] map[v2:map[value:2]] map[v3:map[value:3]]]] <nil>
+}
+
+func ExampleMarshalGo_withError() {
+	type Element struct {
+		Name  string `hcl:",key"`
+		Value int    `hcl:"value,key"`
+	}
+
+	type Struct struct {
+		Elements []Element `hcl:"elements,omitempty"`
+	}
+
+	var main Struct
+	main.Elements = []Element{{"v1", 1}, {"v2", 2}, {"v3", 3}}
+	fmt.Println(MarshalGo(main))
+
+	// Output:
+	// <nil> Multiple keys defined on struct 'Element' ('Name' and 'Value')
 }

--- a/collections/implementation/base_helper.go
+++ b/collections/implementation/base_helper.go
@@ -3,15 +3,11 @@ package implementation
 import (
 	"fmt"
 	"reflect"
-
-	"github.com/coveo/gotemplate/v3/errors"
 )
 
 type helperBase = BaseHelper
 type helperList = ListHelper
 type helperDict = DictHelper
-
-var must = errors.Must
 
 // BaseHelper implements basic functionalities required for both IGenericList & IDictionary
 type BaseHelper struct {

--- a/collections/implementation/generic.go
+++ b/collections/implementation/generic.go
@@ -2,6 +2,7 @@ package implementation
 
 import (
 	"github.com/coveo/gotemplate/v3/collections"
+	"github.com/coveo/gotemplate/v3/errors"
 )
 
 // ListTypeName implementation of IGenericList for baseList
@@ -87,7 +88,7 @@ func (d baseDict) GetValues() baseIList                { return baseDictHelper.G
 func (d baseDict) Has(keys ...interface{}) bool        { return baseDictHelper.Has(d, keys) }
 func (d baseDict) KeysAsString() strArray              { return baseDictHelper.KeysAsString(d) }
 func (d baseDict) Len() int                            { return len(d) }
-func (d baseDict) Native() interface{}                 { return collections.ToNativeRepresentation(d) }
+func (d baseDict) Native() interface{}                 { return must(collections.MarshalGo(d)) }
 func (d baseDict) Pop(keys ...interface{}) interface{} { return baseDictHelper.Pop(d, keys) }
 func (d baseDict) Set(key, v interface{}) baseIDict    { return baseDictHelper.Set(d, key, v) }
 func (d baseDict) Transpose() baseIDict                { return baseDictHelper.Transpose(d) }
@@ -135,4 +136,7 @@ type (
 	strArray = collections.StringArray
 )
 
-var iif = collections.IIf
+var (
+	iif  = collections.IIf
+	must = errors.Must
+)

--- a/hcl/generated_impl.go
+++ b/hcl/generated_impl.go
@@ -4,7 +4,10 @@
 
 package hcl
 
-import "github.com/coveo/gotemplate/v3/collections"
+import (
+	"github.com/coveo/gotemplate/v3/collections"
+	"github.com/coveo/gotemplate/v3/errors"
+)
 
 // List implementation of IGenericList for hclList
 type List = hclList
@@ -95,7 +98,7 @@ func (d hclDict) GetValues() hclIList                 { return hclDictHelper.Get
 func (d hclDict) Has(keys ...interface{}) bool        { return hclDictHelper.Has(d, keys) }
 func (d hclDict) KeysAsString() strArray              { return hclDictHelper.KeysAsString(d) }
 func (d hclDict) Len() int                            { return len(d) }
-func (d hclDict) Native() interface{}                 { return collections.ToNativeRepresentation(d) }
+func (d hclDict) Native() interface{}                 { return must(collections.MarshalGo(d)) }
 func (d hclDict) Pop(keys ...interface{}) interface{} { return hclDictHelper.Pop(d, keys) }
 func (d hclDict) Set(key, v interface{}) hclIDict     { return hclDictHelper.Set(d, key, v) }
 func (d hclDict) Transpose() hclIDict                 { return hclDictHelper.Transpose(d) }
@@ -143,4 +146,7 @@ type (
 	strArray = collections.StringArray
 )
 
-var iif = collections.IIf
+var (
+	iif  = collections.IIf
+	must = errors.Must
+)

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -83,24 +83,33 @@ func Load(filename string) (result interface{}, err error) {
 func Marshal(value interface{}) ([]byte, error) { return MarshalIndent(value, "", "") }
 
 // MarshalIndent serialize values to hcl format with indentation
-func MarshalIndent(value interface{}, prefix, indent string) ([]byte, error) {
-	result, err := marshalHCL(collections.ToNativeRepresentation(value), true, true, prefix, indent)
-	return []byte(result), err
+func MarshalIndent(value interface{}, prefix, indent string) (result []byte, err error) {
+	if value, err = collections.MarshalGo(value); err != nil {
+		return
+	}
+	s, err := marshalHCL(value, true, true, prefix, indent)
+	return []byte(s), err
 }
 
 // MarshalInternal serialize values to hcl format for result used in outer hcl struct
-func MarshalInternal(value interface{}) ([]byte, error) {
-	result, err := marshalHCL(collections.ToNativeRepresentation(value), false, false, "", "")
-	return []byte(result), err
+func MarshalInternal(value interface{}) (result []byte, err error) {
+	if value, err = collections.MarshalGo(value); err != nil {
+		return
+	}
+	s, err := marshalHCL(value, false, false, "", "")
+	return []byte(s), err
 }
 
 // MarshalTFVars serialize values to hcl format (without hcl map format)
 func MarshalTFVars(value interface{}) ([]byte, error) { return MarshalTFVarsIndent(value, "", "") }
 
 // MarshalTFVarsIndent serialize values to hcl format with indentation (without hcl map format)
-func MarshalTFVarsIndent(value interface{}, prefix, indent string) ([]byte, error) {
-	result, err := marshalHCL(collections.ToNativeRepresentation(value), false, true, prefix, indent)
-	return []byte(result), err
+func MarshalTFVarsIndent(value interface{}, prefix, indent string) (result []byte, err error) {
+	if value, err = collections.MarshalGo(value); err != nil {
+		return
+	}
+	s, err := marshalHCL(value, false, true, prefix, indent)
+	return []byte(s), err
 }
 
 // SingleContext converts array of 1 to single object otherwise, let the context unchanged

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -2,10 +2,10 @@ package hcl
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/coveo/gotemplate/v3/collections"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_list_String(t *testing.T) {
@@ -23,9 +23,7 @@ func Test_list_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.l.String(); got != tt.want {
-				t.Errorf("hclList.String() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, tt.l.String())
 		})
 	}
 }
@@ -44,9 +42,7 @@ func Test_dict_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.d.String(); got != tt.want {
-				t.Errorf("hclList.String():\n got %v\nwant %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, tt.d.String())
 		})
 	}
 }
@@ -97,10 +93,11 @@ func TestMarshalHCLVars(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value := collections.ToNativeRepresentation(tt.args.value)
-			if got, _ := marshalHCL(value, true, true, "", tt.args.indent); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MarshalHCLVars() =\n%v\n\nwant:\n%v", got, tt.want)
-			}
+			value, err := collections.MarshalGo(tt.args.value)
+			assert.NoError(t, err)
+			got, err := marshalHCL(value, true, true, "", tt.args.indent)
+			assert.Equal(t, tt.want, got)
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -109,27 +106,22 @@ func TestUnmarshal(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		hcl     string
-		want    interface{}
-		wantErr bool
+		name string
+		hcl  string
+		want interface{}
 	}{
-		{"Empty", "", hclDict{}, false},
-		{"Empty list", "[]", hclList{}, false},
-		{"List of int", "[1,2,3]", hclList{1, 2, 3}, false},
-		{"Array of map", "a { b { c { d = 1 e = 2 }}}", hclDict{"a": hclDict{"b": hclDict{"c": hclDict{"d": 1, "e": 2}}}}, false},
-		{"Map", fmt.Sprint(dictFixture), dictFixture, false},
+		{"Empty", "", hclDict{}},
+		{"Empty list", "[]", hclList{}},
+		{"List of int", "[1,2,3]", hclList{1, 2, 3}},
+		{"Array of map", "a { b { c { d = 1 e = 2 }}}", hclDict{"a": hclDict{"b": hclDict{"c": hclDict{"d": 1, "e": 2}}}}},
+		{"Map", fmt.Sprint(dictFixture), dictFixture},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out interface{}
 			err := Unmarshal([]byte(tt.hcl), &out)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err == nil && !reflect.DeepEqual(out, tt.want) {
-				t.Errorf("Unmarshal:\n got %[1]v (%[1]T)\nwant %[2]v (%[2]T)", out, tt.want)
-			}
+			assert.Equal(t, tt.want, out)
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -141,23 +133,23 @@ func TestUnmarshalStrict(t *testing.T) {
 		name    string
 		hcl     string
 		want    interface{}
-		wantErr bool
+		wantErr error
 	}{
-		{"Empty", "", map[string]interface{}{}, false},
-		{"Empty list", "[]", nil, true},
-		{"List of int", "[1,2,3]", nil, true},
-		{"Array of map", "a { b { c { d = 1 e = 2 }}}", map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c": map[string]interface{}{"d": 1, "e": 2}}}}, false},
-		{"Map", fmt.Sprint(dictFixture), dictFixture.Native(), false},
+		{"Empty", "", map[string]interface{}{}, nil},
+		{"Empty list", "[]", map[string]interface{}(nil), fmt.Errorf("reflect.Set: value of type []interface {} is not assignable to type map[string]interface {}")},
+		{"List of int", "[1,2,3]", map[string]interface{}(nil), fmt.Errorf("reflect.Set: value of type []interface {} is not assignable to type map[string]interface {}")},
+		{"Array of map", "a { b { c { d = 1 e = 2 }}}", map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c": map[string]interface{}{"d": 1, "e": 2}}}}, nil},
+		{"Map", fmt.Sprint(dictFixture), dictFixture.Native(), nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out map[string]interface{}
 			err := Unmarshal([]byte(tt.hcl), &out)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err == nil && !reflect.DeepEqual(out, tt.want) {
-				t.Errorf("Unmarshal:\n got %[1]v (%[1]T)\nwant %[2]v (%[2]T)", out, tt.want)
+			assert.Equal(t, tt.want, out)
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr.Error())
 			}
 		})
 	}

--- a/json/generated_impl.go
+++ b/json/generated_impl.go
@@ -4,7 +4,10 @@
 
 package json
 
-import "github.com/coveo/gotemplate/v3/collections"
+import (
+	"github.com/coveo/gotemplate/v3/collections"
+	"github.com/coveo/gotemplate/v3/errors"
+)
 
 // List implementation of IGenericList for jsonList
 type List = jsonList
@@ -95,7 +98,7 @@ func (d jsonDict) GetValues() jsonIList                { return jsonDictHelper.G
 func (d jsonDict) Has(keys ...interface{}) bool        { return jsonDictHelper.Has(d, keys) }
 func (d jsonDict) KeysAsString() strArray              { return jsonDictHelper.KeysAsString(d) }
 func (d jsonDict) Len() int                            { return len(d) }
-func (d jsonDict) Native() interface{}                 { return collections.ToNativeRepresentation(d) }
+func (d jsonDict) Native() interface{}                 { return must(collections.MarshalGo(d)) }
 func (d jsonDict) Pop(keys ...interface{}) interface{} { return jsonDictHelper.Pop(d, keys) }
 func (d jsonDict) Set(key, v interface{}) jsonIDict    { return jsonDictHelper.Set(d, key, v) }
 func (d jsonDict) Transpose() jsonIDict                { return jsonDictHelper.Transpose(d) }
@@ -143,4 +146,7 @@ type (
 	strArray = collections.StringArray
 )
 
-var iif = collections.IIf
+var (
+	iif  = collections.IIf
+	must = errors.Must
+)

--- a/xml/generated_impl.go
+++ b/xml/generated_impl.go
@@ -4,7 +4,10 @@
 
 package xml
 
-import "github.com/coveo/gotemplate/v3/collections"
+import (
+	"github.com/coveo/gotemplate/v3/collections"
+	"github.com/coveo/gotemplate/v3/errors"
+)
 
 // List implementation of IGenericList for xmlList
 type List = xmlList
@@ -95,7 +98,7 @@ func (d xmlDict) GetValues() xmlIList                 { return xmlDictHelper.Get
 func (d xmlDict) Has(keys ...interface{}) bool        { return xmlDictHelper.Has(d, keys) }
 func (d xmlDict) KeysAsString() strArray              { return xmlDictHelper.KeysAsString(d) }
 func (d xmlDict) Len() int                            { return len(d) }
-func (d xmlDict) Native() interface{}                 { return collections.ToNativeRepresentation(d) }
+func (d xmlDict) Native() interface{}                 { return must(collections.MarshalGo(d)) }
 func (d xmlDict) Pop(keys ...interface{}) interface{} { return xmlDictHelper.Pop(d, keys) }
 func (d xmlDict) Set(key, v interface{}) xmlIDict     { return xmlDictHelper.Set(d, key, v) }
 func (d xmlDict) Transpose() xmlIDict                 { return xmlDictHelper.Transpose(d) }
@@ -143,4 +146,7 @@ type (
 	strArray = collections.StringArray
 )
 
-var iif = collections.IIf
+var (
+	iif  = collections.IIf
+	must = errors.Must
+)

--- a/yaml/generated_impl.go
+++ b/yaml/generated_impl.go
@@ -4,7 +4,10 @@
 
 package yaml
 
-import "github.com/coveo/gotemplate/v3/collections"
+import (
+	"github.com/coveo/gotemplate/v3/collections"
+	"github.com/coveo/gotemplate/v3/errors"
+)
 
 // List implementation of IGenericList for yamlList
 type List = yamlList
@@ -95,7 +98,7 @@ func (d yamlDict) GetValues() yamlIList                { return yamlDictHelper.G
 func (d yamlDict) Has(keys ...interface{}) bool        { return yamlDictHelper.Has(d, keys) }
 func (d yamlDict) KeysAsString() strArray              { return yamlDictHelper.KeysAsString(d) }
 func (d yamlDict) Len() int                            { return len(d) }
-func (d yamlDict) Native() interface{}                 { return collections.ToNativeRepresentation(d) }
+func (d yamlDict) Native() interface{}                 { return must(collections.MarshalGo(d)) }
 func (d yamlDict) Pop(keys ...interface{}) interface{} { return yamlDictHelper.Pop(d, keys) }
 func (d yamlDict) Set(key, v interface{}) yamlIDict    { return yamlDictHelper.Set(d, key, v) }
 func (d yamlDict) Transpose() yamlIDict                { return yamlDictHelper.Transpose(d) }
@@ -143,4 +146,7 @@ type (
 	strArray = collections.StringArray
 )
 
-var iif = collections.IIf
+var (
+	iif  = collections.IIf
+	must = errors.Must
+)


### PR DESCRIPTION
- Rename the function ToNativeRepresentation() to MarshalGo()
- Add error management
- Add support to custom marshaler implementation
- Properly support key tag
- Properly handle empty structure and empty map when omitempty is set
- Add more examples/tests
- Simplify some tests using assert package
- Fix a typo in the Makefile (space missing)
